### PR TITLE
Update Wiki page content

### DIFF
--- a/simple_ado/__init__.py
+++ b/simple_ado/__init__.py
@@ -21,6 +21,7 @@ from simple_ado.pools import ADOPoolsClient
 from simple_ado.pull_requests import ADOPullRequestClient
 from simple_ado.security import ADOSecurityClient
 from simple_ado.user import ADOUserClient
+from simple_ado.wiki import ADOWikiClient
 from simple_ado.workitems import ADOWorkItemsClient
 
 
@@ -47,6 +48,7 @@ class ADOClient:
     pools: ADOPoolsClient
     security: ADOSecurityClient
     user: ADOUserClient
+    wiki: ADOWikiClient
     workitems: ADOWorkItemsClient
 
     def __init__(
@@ -80,6 +82,7 @@ class ADOClient:
         self.pools = ADOPoolsClient(self.http_client, self.log)
         self.security = ADOSecurityClient(self.http_client, self.log)
         self.user = ADOUserClient(self.http_client, self.log)
+        self.wiki = ADOWikiClient(self.http_client, self.log)
         self.workitems = ADOWorkItemsClient(self.http_client, self.log)
 
     def verify_access(self) -> bool:

--- a/simple_ado/wiki.py
+++ b/simple_ado/wiki.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
@@ -7,6 +5,7 @@
 
 import logging
 
+from simple_ado.exceptions import ADOException
 from simple_ado.base_client import ADOBaseClient
 from simple_ado.http_client import ADOHTTPClient, ADOResponse
 
@@ -31,6 +30,8 @@ class ADOWikiClient(ADOBaseClient):
         :param str project_id: The ID of the project
 
         :returns: The ADO response with the data in it
+
+        :raises ADOException: If we fail to fetch the page version.
         """
 
         self.log.debug(f"Get wiki page: {page_id}")
@@ -40,7 +41,10 @@ class ADOWikiClient(ADOBaseClient):
         )
         response = self.http_client.get(request_url)
         self.http_client.validate_response(response)
-        return response.headers["ETag"]
+        etag = response.headers.get("ETag")
+        if not etag:
+            raise ADOException("No ETag returned for wiki page.")
+        return etag
 
     def update_page(
         self, page_id: str, wiki_id: str, project_id: str, content: str, current_version_etag: str

--- a/simple_ado/wiki.py
+++ b/simple_ado/wiki.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+"""ADO Wiki API wrapper."""
+
+import logging
+
+from simple_ado.base_client import ADOBaseClient
+from simple_ado.http_client import ADOHTTPClient, ADOResponse
+
+
+class ADOWikiClient(ADOBaseClient):
+    """Wrapper class around the ADO Wiki APIs.
+
+    :param http_client: The HTTP client to use for the client
+    :param log: The logger to use
+    """
+
+    def __init__(self, http_client: ADOHTTPClient, log: logging.Logger) -> None:
+        super().__init__(http_client, log.getChild("wiki"))
+
+    def get_page_version(self, page_id: str, wiki_id: str, project_id: str) -> ADOResponse:
+        """Get's the current version of a wiki page. This returns a required parameter for updating a wiki page.
+
+        https://docs.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/get%20page%20by%20id?view=azure-devops-rest-6.1
+
+        :param page_id: Wiki page ID
+        :param wiki_id: Wiki ID or Wiki name
+        :param str project_id: The ID of the project
+
+        :returns: The ADO response with the data in it
+        """
+
+        self.log.debug(f"Get wiki page: {page_id}")
+        request_url = (
+            self.http_client.api_endpoint(is_default_collection=False, project_id=project_id)
+            + f"/wiki/wikis/{wiki_id}/pages/{page_id}?api-version=6.1-preview.1"
+        )
+        response = self.http_client.get(request_url)
+        self.http_client.validate_response(response)
+        return response.headers["ETag"]
+
+    def update_page(
+        self, page_id: str, wiki_id: str, project_id: str, content: str, current_version_etag: str
+    ) -> ADOResponse:
+        """Update a the contents of a wiki page.
+
+        https://docs.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/update?view=azure-devops-rest-6.1
+
+        :param page_id: Wiki page ID
+        :param wiki_id: Wiki ID or Wiki name
+        :param str project_id: The ID of the project
+        :param str content: Content of the wiki page.
+        :param str current_version_etag: The ETag of the current wiki page to verify the update.
+
+        :returns: The ADO response with the data in it
+        """
+
+        self.log.debug(f"Updating wiki page: {page_id}")
+        request_url = (
+            self.http_client.api_endpoint(is_default_collection=False, project_id=project_id)
+            + f"/wiki/wikis/{wiki_id}/pages/{page_id}?api-version=6.1-preview.1"
+        )
+        response = self.http_client.patch(
+            request_url,
+            json_data={"content": content,},
+            additional_headers={
+                "Content-Type": "application/json",
+                "If-Match": current_version_etag,
+            },
+        )
+        return self.http_client.decode_response(response)


### PR DESCRIPTION
Adds methods to update a Wiki's page on ADO. The current page's version is required when updating so there are two API calls that need to be made here.

Example usage:
```python
page_version = ado_client.wiki.get_page_version(page_id=1, wiki_id="wiki", project_id="project")
ado_client.wiki.update_page(page_id=1, wiki_id="wiki", project_id="project", content="Testing updates", current_version_etag=page_version)
```