### PR TITLE
Dalemyers/artifacts download

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,16 +22,16 @@ classifiers = [
     'Environment :: MacOS X',
     'Intended Audience :: Developers',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Software Development',
     'Topic :: Utilities'
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 deserialize = "^2.0.1"
 requests = "^2.31.0"
 tenacity = "^8.2.2"

--- a/simple_ado/__init__.py
+++ b/simple_ado/__init__.py
@@ -6,7 +6,7 @@
 """ADO API wrapper."""
 
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Iterator
 import urllib.parse
 
 import requests
@@ -32,11 +32,11 @@ from simple_ado.workitems import ADOWorkItemsClient
 class ADOClient:
     """Wrapper class around the ADO API.
 
-    :param str tenant: The ADO tenant to connect to
-    :param Tuple[str,str] credentials: The credentials to use for the API connection
-    :param Optional[str] user_agent: The user agent to set
-    :param Optional[Dict[str,str]] extra_headers: Any extra headers which should be sent with the API requests
-    :param Optional[logging.Logger] log: The logger to use for logging (a new one will be used if one is not supplied)
+    :param tenant: The ADO tenant to connect to
+    :param credentials: The credentials to use for the API connection
+    :param user_agent: The user agent to set
+    :param extra_headers: Any extra headers which should be sent with the API requests
+    :param log: The logger to use for logging (a new one will be used if one is not supplied)
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -63,10 +63,10 @@ class ADOClient:
         self,
         *,
         tenant: str,
-        credentials: Tuple[str, str],
-        user_agent: Optional[str] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-        log: Optional[logging.Logger] = None,
+        credentials: tuple[str, str],
+        user_agent: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+        log: logging.Logger | None = None,
     ) -> None:
         """Construct a new client object."""
 
@@ -123,19 +123,19 @@ class ADOClient:
         target_branch: str,
         project_id: str,
         repository_id: str,
-        title: Optional[str] = None,
-        description: Optional[str] = None,
-        reviewer_ids: Optional[List[str]] = None,
+        title: str | None = None,
+        description: str | None = None,
+        reviewer_ids: list[str] | None = None,
     ) -> ADOResponse:
         """Creates a pull request with the given information
 
-        :param str source_branch: The source branch of the pull request
-        :param str target_branch: The target branch of the pull request
+        :param source_branch: The source branch of the pull request
+        :param target_branch: The target branch of the pull request
         :param project_id: The ID of the project
-        :param str repository_id: The ID for the repository
-        :param Optional[str] title: The title of the pull request
-        :param Optional[str] description: The description of the pull request
-        :param Optional[List[str]] reviewer_ids: The reviewer IDs to be added to the pull request
+        :param repository_id: The ID for the repository
+        :param title: The title of the pull request
+        :param description: The description of the pull request
+        :param reviewer_ids: The reviewer IDs to be added to the pull request
 
         :returns: The ADO response with the data in it
 
@@ -146,7 +146,7 @@ class ADOClient:
         request_url = f"{self.http_client.api_endpoint(project_id=project_id)}/git/repositories/{repository_id}"
         request_url += "/pullRequests?api-version=5.1"
 
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "sourceRefName": _canonicalize_branch_name(source_branch),
             "targetRefName": _canonicalize_branch_name(target_branch),
         }
@@ -181,7 +181,7 @@ class ADOClient:
     def list_all_pull_requests(
         self,
         *,
-        branch_name: Optional[str] = None,
+        branch_name: str | None = None,
         project_id: str,
         repository_id: str,
         top: int | None = None,
@@ -189,10 +189,11 @@ class ADOClient:
     ) -> Iterator[Any]:
         """Get the pull requests for a branch from ADO.
 
-        :param Optional[str] branch_name: The name of the branch to fetch the pull requests for.
+        :param branch_name: The name of the branch to fetch the pull requests for.
         :param project_id: The ID of the project
-        :param str repository_id: The ID for the repository
+        :param repository_id: The ID for the repository
         :param top: How many PRs to retrieve
+        :param pr_status: Set to filter by only PRs with that status
 
         :returns: The ADO Response with the pull request data
         """
@@ -207,7 +208,7 @@ class ADOClient:
                 + f"/git/repositories/{repository_id}/pullRequests?"
             )
 
-            parameters = {"$skip": offset}
+            parameters: dict[str, Any] = {"$skip": offset}
 
             if top:
                 parameters["$top"] = top
@@ -240,11 +241,11 @@ class ADOClient:
         self,
         *,
         url_fragment: str,
-        parameters: Dict[str, Any],
+        parameters: dict[str, Any],
         is_default_collection: bool = True,
         is_internal: bool = False,
-        subdomain: Optional[str] = None,
-        project_id: Optional[str] = None,
+        subdomain: str | None = None,
+        project_id: str | None = None,
     ) -> ADOResponse:
         """Perform a custom GET REST request.
 
@@ -257,12 +258,12 @@ class ADOClient:
         exposed in a generic manner. For these cases, the requests should be
         built manually.
 
-        :param str url_fragment: The part of the URL that comes after `_apis/`
-        :param Dict[str,Any] parameters: The URL parameters to append
-        :param bool is_default_collection: Whether this URL should start with the path "/DefaultCollection"
-        :param bool is_internal: Whether this URL should use internal API endpoint "/_api"
-        :param Optional[str] subdomain: A subdomain that should be used (if any)
-        :param Optional[str] project_id: The project ID (if required)
+        :param url_fragment: The part of the URL that comes after `_apis/`
+        :param parameters: The URL parameters to append
+        :param is_default_collection: Whether this URL should start with the path "/DefaultCollection"
+        :param is_internal: Whether this URL should use internal API endpoint "/_api"
+        :param subdomain: A subdomain that should be used (if any)
+        :param project_id: The project ID (if required)
 
         :returns: The raw response
         """

--- a/simple_ado/__init__.py
+++ b/simple_ado/__init__.py
@@ -11,6 +11,7 @@ import urllib.parse
 
 import requests
 
+from simple_ado.auth.ado_auth import ADOAuth
 from simple_ado.audit import ADOAuditClient
 from simple_ado.builds import ADOBuildClient
 from simple_ado.endpoints import ADOEndpointsClient
@@ -33,7 +34,7 @@ class ADOClient:
     """Wrapper class around the ADO API.
 
     :param tenant: The ADO tenant to connect to
-    :param credentials: The credentials to use for the API connection
+    :param auth: The auth details to use for the API connection
     :param user_agent: The user agent to set
     :param extra_headers: Any extra headers which should be sent with the API requests
     :param log: The logger to use for logging (a new one will be used if one is not supplied)
@@ -63,7 +64,7 @@ class ADOClient:
         self,
         *,
         tenant: str,
-        credentials: tuple[str, str],
+        auth: ADOAuth,
         user_agent: str | None = None,
         extra_headers: dict[str, str] | None = None,
         log: logging.Logger | None = None,
@@ -77,7 +78,7 @@ class ADOClient:
 
         self.http_client = ADOHTTPClient(
             tenant=tenant,
-            credentials=credentials,
+            auth=auth,
             user_agent=user_agent if user_agent is not None else tenant,
             log=self.log,
             extra_headers=extra_headers,

--- a/simple_ado/audit.py
+++ b/simple_ado/audit.py
@@ -7,7 +7,7 @@
 
 import datetime
 import logging
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Iterator
 import urllib.parse
 
 import deserialize
@@ -27,7 +27,7 @@ class ADOAuditClient(ADOBaseClient):
     def __init__(self, http_client: ADOHTTPClient, log: logging.Logger) -> None:
         super().__init__(http_client, log.getChild("audit"))
 
-    def get_actions(self, area_name: Optional[str] = None) -> List[AuditActionInfo]:
+    def get_actions(self, area_name: str | None = None) -> list[AuditActionInfo]:
         """Get the list of audit actions.
 
         :param area_name: The optional area name to scope down to
@@ -48,14 +48,14 @@ class ADOAuditClient(ADOBaseClient):
         response = self.http_client.get(request_url)
         response_data = self.http_client.decode_response(response)
         raw_actions = self.http_client.extract_value(response_data)
-        return deserialize.deserialize(List[AuditActionInfo], raw_actions)
+        return deserialize.deserialize(list[AuditActionInfo], raw_actions)
 
     def query(
         self,
-        start_time: Optional[datetime.datetime] = None,
-        end_time: Optional[datetime.datetime] = None,
-        skip_aggregation: Optional[bool] = None,
-    ) -> Iterator[Dict[str, Any]]:
+        start_time: datetime.datetime | None = None,
+        end_time: datetime.datetime | None = None,
+        skip_aggregation: bool | None = None,
+    ) -> Iterator[dict[str, Any]]:
         """Query the audit log.
 
         :param start_time: The earliest point to query (rounds down to the nearest second)

--- a/simple_ado/auth/__init__.py
+++ b/simple_ado/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Umbrella module for all authentication classes."""
+
+from .ado_auth import ADOAuth
+from .ado_basic_auth import ADOBasicAuth
+from .ado_token_auth import ADOTokenAuth

--- a/simple_ado/auth/ado_auth.py
+++ b/simple_ado/auth/ado_auth.py
@@ -1,0 +1,13 @@
+"""Base auth class."""
+
+import abc
+
+
+class ADOAuth(abc.ABC):
+    """Base class for authentication."""
+
+    def get_authorization_header(self) -> str:
+        """Get the header value.
+
+        :return: The header value."""
+        raise NotImplementedError()

--- a/simple_ado/auth/ado_basic_auth.py
+++ b/simple_ado/auth/ado_basic_auth.py
@@ -1,0 +1,25 @@
+"""Basic authentication auth class."""
+
+import base64
+import functools
+from simple_ado.auth.ado_auth import ADOAuth
+
+
+class ADOBasicAuth(ADOAuth):
+    """Username/password auth. Also supports PATs."""
+
+    username: str
+    password: str
+
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+
+    @functools.lru_cache(maxsize=1)
+    def get_authorization_header(self) -> str:
+        """Get the header value.
+
+        :return: The header value."""
+
+        username_password_bytes = (self.username + ":" + self.password).encode("utf-8")
+        return "Basic " + base64.b64encode(username_password_bytes).decode("utf-8")

--- a/simple_ado/auth/ado_token_auth.py
+++ b/simple_ado/auth/ado_token_auth.py
@@ -1,0 +1,19 @@
+"""Token authentication auth class."""
+
+from simple_ado.auth.ado_auth import ADOAuth
+
+
+class ADOTokenAuth(ADOAuth):
+    """Token auth."""
+
+    token: str
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def get_authorization_header(self) -> str:
+        """Get the header value.
+
+        :return: The header value."""
+
+        return "Bearer " + self.token

--- a/simple_ado/builds.py
+++ b/simple_ado/builds.py
@@ -7,7 +7,7 @@
 
 import json
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Iterator
 import urllib.parse
 
 
@@ -33,12 +33,12 @@ class ADOBuildClient(ADOBaseClient):
         project_id: str,
         definition_id: int,
         source_branch: str,
-        variables: Dict[str, str],
-        requesting_identity: Optional[TeamFoundationId] = None,
+        variables: dict[str, str],
+        requesting_identity: TeamFoundationId | None = None,
     ) -> ADOResponse:
         """Queue a new build.
 
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
         :param definition_id: The identity of the build definition to queue (can be a string)
         :param source_branch: The source branch for the build
         :param variables: A dictionary of variables to pass to the definition
@@ -69,8 +69,8 @@ class ADOBuildClient(ADOBaseClient):
     def build_info(self, *, project_id: str, build_id: int) -> ADOResponse:
         """Get the info for a build.
 
-        :param str project_id: The ID of the project
-        :param int build_id: The identifier of the build to get the info for
+        :param project_id: The ID of the project
+        :param build_id: The identifier of the build to get the info for
 
         :returns: The ADO response with the data in it
         """
@@ -86,12 +86,12 @@ class ADOBuildClient(ADOBaseClient):
         self,
         *,
         project_id: str,
-        definitions: Optional[List[int]] = None,
-    ) -> Iterator[Dict[str, Any]]:
+        definitions: list[int] | None = None,
+    ) -> Iterator[dict[str, Any]]:
         """Get the info for a build.
 
-        :param str project_id: The ID of the project
-        :param int definitions: An optional list of build definition IDs to filter on
+        :param project_id: The ID of the project
+        :param definitions: An optional list of build definition IDs to filter on
 
         :returns: The ADO response with the data in it
         """
@@ -128,7 +128,7 @@ class ADOBuildClient(ADOBaseClient):
     ) -> ADOResponse:
         """Fetch an artifacts details from a build.
 
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
         :param build_id: The ID of the build
         :param artifact_name: The name of the artifact to fetch
 
@@ -153,10 +153,10 @@ class ADOBuildClient(ADOBaseClient):
     ) -> None:
         """Download an artifact from a build.
 
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
         :param build_id: The ID of the build
         :param artifact_name: The name of the artifact to fetch
-        :param str output_path: The path to write the output to.
+        :param output_path: The path to write the output to.
         """
 
         parameters = {
@@ -176,7 +176,7 @@ class ADOBuildClient(ADOBaseClient):
     def get_leases(self, *, project_id: str, build_id: int) -> ADOResponse:
         """Get the retention leases for a build.
 
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
         :param build_id: The ID of the build
 
         :returns: The ADO response with the data in it
@@ -193,10 +193,10 @@ class ADOBuildClient(ADOBaseClient):
         response_data = self.http_client.decode_response(response)
         return self.http_client.extract_value(response_data)
 
-    def delete_leases(self, *, project_id: str, lease_ids: Union[int, List[int]]) -> None:
+    def delete_leases(self, *, project_id: str, lease_ids: int | list[int]) -> None:
         """Delete leases.
 
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
         :param lease_ids: The IDs of the leases to delete
         """
 

--- a/simple_ado/comments.py
+++ b/simple_ado/comments.py
@@ -6,7 +6,7 @@
 """ADO comment utilities"""
 
 import enum
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 
 class ADOCommentStatus(enum.Enum):
@@ -30,7 +30,7 @@ class ADOCommentProperty:
     COMMENT_IDENTIFIER = "3533F9EC-9336-4290-85F7-6A6A51AD1861"
 
     @staticmethod
-    def create_value(type_name: str, value: Union[int, str]) -> Dict[str, Any]:
+    def create_value(type_name: str, value: int | str) -> dict[str, Any]:
         """Create a new property value.
 
         :param type_name: The type of property
@@ -41,7 +41,7 @@ class ADOCommentProperty:
         return {"type": type_name, "value": value}
 
     @staticmethod
-    def create_string(value: str) -> Dict[str, Any]:
+    def create_string(value: str) -> dict[str, Any]:
         """Create a new string value.
 
         :param value: The value of the property
@@ -51,7 +51,7 @@ class ADOCommentProperty:
         return ADOCommentProperty.create_value("System.String", value)
 
     @staticmethod
-    def create_int(value: int) -> Dict[str, Any]:
+    def create_int(value: int) -> dict[str, Any]:
         """Create a new integer value.
 
         :param value: The value of the property
@@ -61,7 +61,7 @@ class ADOCommentProperty:
         return ADOCommentProperty.create_value("System.Int32", value)
 
     @staticmethod
-    def create_bool(value: bool) -> Dict[str, Any]:
+    def create_bool(value: bool) -> dict[str, Any]:
         """Create a new boolean value.
 
         :param value: The value of the property
@@ -74,17 +74,17 @@ class ADOCommentProperty:
 class ADOCommentLocation:
     """Represents the location of a comment in a PR.
 
-    :param str file_path: The location of the file, relative to the repository.
-    :param int line: The line the comment should start on.
+    :param file_path: The location of the file, relative to the repository.
+    :param line: The line the comment should start on.
     :param start_index: The location on the line that the comment should start
     :type start_index: int or None
     """
 
     file_path: str
     line: int
-    start_index: Optional[int]
+    start_index: int | None
 
-    def __init__(self, file_path: str, line: int, start_index: Optional[int] = None) -> None:
+    def __init__(self, file_path: str, line: int, start_index: int | None = None) -> None:
         """Construct a new comment location."""
 
         self.file_path = file_path
@@ -94,7 +94,7 @@ class ADOCommentLocation:
         if not self.file_path.startswith("/"):  # On some machines this is missing, some it's there
             self.file_path = "/" + self.file_path
 
-    def generate_representation(self) -> Dict[str, Any]:
+    def generate_representation(self) -> dict[str, Any]:
         """Generate the ADO API representation of a comment location.
 
         :returns: A dictionary containing the raw API data
@@ -119,24 +119,27 @@ class ADOComment:
     """Represents a ADO comment."""
 
     content: str
-    location: Optional[ADOCommentLocation]
+    location: ADOCommentLocation | None
     parent_id: int
 
     def __init__(
-        self, content: str, location: Optional[ADOCommentLocation] = None, parent_id: int = 0
+        self,
+        content: str,
+        location: ADOCommentLocation | None = None,
+        parent_id: int = 0,
     ) -> None:
         """Construct a new comment.
 
-        :param str content: The message which should be on the comment
-        :param ADOCommentLocation location: The location to place the comment
-        :param int parent_id: The ID of the parent comment (0 if a root comment)
+        :param content: The message which should be on the comment
+        :param location: The location to place the comment
+        :param parent_id: The ID of the parent comment (0 if a root comment)
         """
 
         self.content = content
         self.parent_id = parent_id
         self.location = location
 
-    def generate_representation(self) -> Dict[str, Any]:
+    def generate_representation(self) -> dict[str, Any]:
         """Generate the ADO API representation of this comment.
 
         :returns: A dictionary containing the raw API data

--- a/simple_ado/endpoints.py
+++ b/simple_ado/endpoints.py
@@ -6,7 +6,7 @@
 """ADO service endpoints API wrapper."""
 
 import logging
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Iterator
 import urllib.parse
 
 
@@ -24,7 +24,7 @@ class ADOEndpointsClient(ADOBaseClient):
     def __init__(self, http_client: ADOHTTPClient, log: logging.Logger) -> None:
         super().__init__(http_client, log.getChild("endpoints"))
 
-    def get_endpoints(self, project_id: str, *, endpoint_type: Optional[str] = None) -> ADOResponse:
+    def get_endpoints(self, project_id: str, *, endpoint_type: str | None = None) -> ADOResponse:
         """Gets the service endpoints.
 
         :param project_id: The identifier for the project
@@ -48,8 +48,8 @@ class ADOEndpointsClient(ADOBaseClient):
         return self.http_client.extract_value(response_data)
 
     def get_usage_history(
-        self, *, project_id: str, endpoint_id: str, top: Optional[int] = None
-    ) -> Iterator[Dict[str, Any]]:
+        self, *, project_id: str, endpoint_id: str, top: int | None = None
+    ) -> Iterator[dict[str, Any]]:
         """Gets the usage history for an endpoint.
 
         :param project_id: The identifier for the project
@@ -63,7 +63,7 @@ class ADOEndpointsClient(ADOBaseClient):
             + f"/serviceendpoint/{endpoint_id}/executionhistory?"
         )
 
-        parameters: Dict[str, Any] = {"api-version": "6.0-preview.1"}
+        parameters: dict[str, Any] = {"api-version": "6.0-preview.1"}
 
         if not top or top < 50:
             parameters["top"] = top

--- a/simple_ado/git.py
+++ b/simple_ado/git.py
@@ -8,7 +8,7 @@
 import enum
 import logging
 import os
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable
 import urllib.parse
 
 from simple_ado.base_client import ADOBaseClient
@@ -40,9 +40,7 @@ class ADOReferenceUpdate:
     old_object_id: str
     new_object_id: str
 
-    def __init__(
-        self, name: str, old_object_id: Optional[str], new_object_id: Optional[str]
-    ) -> None:
+    def __init__(self, name: str, old_object_id: str | None, new_object_id: str | None) -> None:
         self.name = name
 
         if old_object_id:
@@ -55,7 +53,7 @@ class ADOReferenceUpdate:
         else:
             self.new_object_id = "0000000000000000000000000000000000000000"
 
-    def json_data(self) -> Dict[str, str]:
+    def json_data(self) -> dict[str, str]:
         """Return the JSON representation for sending to ADO.
 
         :returns: The JSON representation
@@ -81,7 +79,7 @@ class ADOGitClient(ADOBaseClient):
     def all_repositories(self, project_id: str) -> ADOResponse:
         """Get a list of repositories in the project.
 
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
 
         :returns: The ADO response with the data in it
         """
@@ -94,8 +92,8 @@ class ADOGitClient(ADOBaseClient):
     def get_repository(self, *, project_id: str, repository_id: str) -> ADOResponse:
         """Get a repository from the project.
 
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID of the repository
+        :param project_id: The ID of the project
+        :param repository_id: The ID of the repository
 
         :returns: The ADO response with the data in it
         """
@@ -110,9 +108,9 @@ class ADOGitClient(ADOBaseClient):
     def get_status(self, *, sha: str, project_id: str, repository_id: str) -> ADOResponse:
         """Set a status on a PR.
 
-        :param str sha: The SHA of the commit to add the status to.
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
+        :param sha: The SHA of the commit to add the status to.
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
 
@@ -143,18 +141,18 @@ class ADOGitClient(ADOBaseClient):
         project_id: str,
         repository_id: str,
         context: str,
-        target_url: Optional[str] = None,
+        target_url: str | None = None,
     ) -> ADOResponse:
         """Set a status on a PR.
 
-        :param str sha: The SHA of the commit to add the status to.
-        :param ADOGitStatusState state: The state to set the status to.
-        :param str identifier: A unique identifier for the status (so it can be changed later)
-        :param str description: The text to show in the status
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
-        :param str context: The context to use for build status notifications
-        :param Optional[str] target_url: An optional URL to set which is opened when the description is clicked.
+        :param sha: The SHA of the commit to add the status to.
+        :param state: The state to set the status to.
+        :param identifier: A unique identifier for the status (so it can be changed later)
+        :param description: The text to show in the status
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
+        :param context: The context to use for build status notifications
+        :param target_url: An optional URL to set which is opened when the description is clicked.
 
         :returns: The ADO response with the data in it
 
@@ -197,10 +195,10 @@ class ADOGitClient(ADOBaseClient):
     ) -> ADOResponse:
         """Get the diff between two commits.
 
-        :param str base_commit: The full hash of the base commit to perform the diff against.
-        :param str target_commit: The full hash of the commit to perform the diff of.
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
+        :param base_commit: The full hash of the base commit to perform the diff against.
+        :param target_commit: The full hash of the commit to perform the diff of.
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -216,7 +214,6 @@ class ADOGitClient(ADOBaseClient):
         skip = 0
 
         while True:
-
             parameters = {
                 "api-version": "5.1",
                 "baseVersionType": "commit",
@@ -247,14 +244,14 @@ class ADOGitClient(ADOBaseClient):
         output_path: str,
         project_id: str,
         repository_id: str,
-        callback: Optional[Callable[[int, int], None]] = None
+        callback: Callable[[int, int], None] | None = None,
     ) -> None:
         """Download the zip of the branch specified.
 
-        :param str branch: The name of the branch to download.
-        :param str output_path: The path to write the output to.
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
+        :param branch: The name of the branch to download.
+        :param output_path: The path to write the output to.
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
         :param callback: The callback for download progress updates. First
                          parameter is bytes downloaded, second is total bytes.
                          The latter will be 0 if the content length is unknown.
@@ -286,7 +283,7 @@ class ADOGitClient(ADOBaseClient):
                 response=response,
                 output_path=output_path,
                 log=self.log,
-                callback=callback
+                callback=callback,
             )
 
     # pylint: disable=too-many-locals
@@ -295,48 +292,48 @@ class ADOGitClient(ADOBaseClient):
         *,
         project_id: str,
         repository_id: str,
-        filter_startswith: Optional[str] = None,
-        filter_contains: Optional[str] = None,
-        include_links: Optional[bool] = None,
-        include_statuses: Optional[bool] = None,
-        include_my_branches: Optional[bool] = None,
-        latest_statuses_only: Optional[bool] = None,
-        peel_tags: Optional[bool] = None,
-        top: Optional[int] = None,
-        continuation_token: Optional[str] = None,
+        filter_startswith: str | None = None,
+        filter_contains: str | None = None,
+        include_links: bool | None = None,
+        include_statuses: bool | None = None,
+        include_my_branches: bool | None = None,
+        latest_statuses_only: bool | None = None,
+        peel_tags: bool | None = None,
+        top: int | None = None,
+        continuation_token: str | None = None,
     ) -> ADOResponse:
         """Set a status on a PR.
 
         All non-specified options use the ADO default.
 
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
-        :param Optional[str] filter_startswith: A filter to apply to the refs
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
+        :param filter_startswith: A filter to apply to the refs
                                                 (starts with)
-        :param Optional[str] filter_contains: A filter to apply to the refs
+        :param filter_contains: A filter to apply to the refs
                                               (contains)
-        :param Optional[bool] include_links: Specifies if referenceLinks should
+        :param include_links: Specifies if referenceLinks should
                                              be included in the result
-        :param Optional[bool] include_statuses: Includes up to the first 1000
+        :param include_statuses: Includes up to the first 1000
                                                 commit statuses for each ref
-        :param Optional[bool] include_my_branches: Includes only branches that
+        :param include_my_branches: Includes only branches that
                                                    the user owns, the branches
                                                    the user favorites, and the
                                                    default branch. Cannot be
                                                    combined with the filter
                                                    parameter.
-        :param Optional[bool] latest_statuses_only: True to include only the tip
+        :param latest_statuses_only: True to include only the tip
                                                     commit status for each ref.
                                                     This requires
                                                     `include_statuses` to be set
                                                     to `True`.
-        :param Optional[bool] peel_tags: Annotated tags will populate the
+        :param peel_tags: Annotated tags will populate the
                                          `PeeledObjectId` property.
-        :param Optional[int] top: Maximum number of refs to return. It cannot be
+        :param top: Maximum number of refs to return. It cannot be
                                   bigger than 1000. If it is not provided, but
                                   `continuation_token` is, top will default to
                                   100.
-        :param Optional[str] continuation_token: The continuation token used for
+        :param continuation_token: The continuation token used for
                                                  pagination
 
         :returns: The ADO response with the data in it
@@ -348,7 +345,7 @@ class ADOGitClient(ADOBaseClient):
 
         request_url = f"{self.http_client.api_endpoint(project_id=project_id)}/git/repositories/{repository_id}/refs?"
 
-        parameters: Dict[str, Any] = {}
+        parameters: dict[str, Any] = {}
 
         if filter_startswith:
             parameters["filter"] = filter_startswith
@@ -397,9 +394,9 @@ class ADOGitClient(ADOBaseClient):
     ) -> ADOResponse:
         """Get the stats for a branch.
 
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
-        :param str branch_name: The name of the branch to get the stats for
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
+        :param branch_name: The name of the branch to get the stats for
 
         :returns: The ADO response with the data in it
         """
@@ -418,16 +415,16 @@ class ADOGitClient(ADOBaseClient):
         commit_id: str,
         project_id: str,
         repository_id: str,
-        change_count: Optional[int] = None,
+        change_count: int | None = None,
     ) -> ADOResponse:
         """Set a status on a PR.
 
         All non-specified options use the ADO default.
 
-        :param str commit_id: The id of the commit
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
-        :param Optional[int] change_count: The number of changes to include in
+        :param commit_id: The id of the commit
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
+        :param change_count: The number of changes to include in
                                            the result
 
         :returns: The ADO response with the data in it
@@ -447,15 +444,15 @@ class ADOGitClient(ADOBaseClient):
     def update_refs(
         self,
         *,
-        updates: List[ADOReferenceUpdate],
+        updates: list[ADOReferenceUpdate],
         project_id: str,
         repository_id: str,
     ) -> ADOResponse:
         """Update a list of references.
 
-        :param List[ADOReferenceUpdate] updates: The list of updates to make
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
+        :param updates: The list of updates to make
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -478,8 +475,8 @@ class ADOGitClient(ADOBaseClient):
 
         :param branch_name: The full name of the branch. e.g. refs/heads/my_branch
         :param object_id: The ID of the object the branch currently points to
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response
         """
@@ -518,32 +515,32 @@ class ADOGitClient(ADOBaseClient):
         path: str,
         project_id: str,
         repository_id: str,
-        scope_path: Optional[str] = None,
-        recursion_level: Optional[VersionControlRecursionType] = None,
-        include_content_metadata: Optional[bool] = None,
-        latest_processed_changes: Optional[bool] = None,
-        version_options: Optional[GitVersionOptions] = None,
-        version: Optional[str] = None,
-        version_type: Optional[GitVersionType] = None,
-        include_content: Optional[bool] = None,
-        resolve_lfs: Optional[bool] = None,
+        scope_path: str | None = None,
+        recursion_level: VersionControlRecursionType | None = None,
+        include_content_metadata: bool | None = None,
+        latest_processed_changes: bool | None = None,
+        version_options: GitVersionOptions | None = None,
+        version: str | None = None,
+        version_type: GitVersionType | None = None,
+        include_content: bool | None = None,
+        resolve_lfs: bool | None = None,
     ) -> ADOResponse:
         """Get a git item.
 
         All non-specified options use the ADO default.
 
-        :param str path: The item path,
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
-        :param Optional[str] scope_path: The path scope
-        :param Optional[VersionControlRecursionType] recursion_level: The recursion level
-        :param Optional[bool] include_content_metadata: Set to include content metadata
-        :param Optional[bool] latest_processed_changes: Set to include the latest changes
-        :param Optional[GitVersionOptions] version_options: Specify additional modifiers to version
-        :param Optional[str] version: Version string identifier (name of tag/branch, SHA1 of commit)
-        :param Optional[GitVersionType] version_type: Version type (branch, tag or commit).
-        :param Optional[bool] include_content: Set to true to include item content when requesting JSON
-        :param Optional[bool] resolve_lfs: Set to true to resolve LFS pointer files to resolve actual content
+        :param path: The item path,
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
+        :param scope_path: The path scope
+        :param recursion_level: The recursion level
+        :param include_content_metadata: Set to include content metadata
+        :param latest_processed_changes: Set to include the latest changes
+        :param version_options: Specify additional modifiers to version
+        :param version: Version string identifier (name of tag/branch, SHA1 of commit)
+        :param version_type: Version type (branch, tag or commit).
+        :param include_content: Set to true to include item content when requesting JSON
+        :param resolve_lfs: Set to true to resolve LFS pointer files to resolve actual content
 
         :returns: The ADO response with the data in it
         """
@@ -552,7 +549,7 @@ class ADOGitClient(ADOBaseClient):
 
         request_url = f"{self.http_client.api_endpoint(project_id=project_id)}/git/repositories/{repository_id}/items?"
 
-        parameters: Dict[str, Any] = {"path": path, "api-version": "5.1"}
+        parameters: dict[str, Any] = {"path": path, "api-version": "5.1"}
 
         if scope_path is not None:
             parameters["scopePath"] = scope_path
@@ -586,53 +583,53 @@ class ADOGitClient(ADOBaseClient):
         response = self.http_client.get(request_url)
         return self.http_client.decode_response(response)
 
-    # pylint: disable=line-too-long
+    # pylint: disable=too-many-locals,line-too-long,too-complex,too-many-branches
     def get_commits(
         self,
         *,
         project_id: str,
         repository_id: str,
-        skip: Optional[int] = None,
-        top: Optional[int] = None,
-        from_date: Optional[str] = None,
-        to_date: Optional[str] = None,
-        from_commit_id: Optional[str] = None,
-        to_commit_id: Optional[str] = None,
-        author: Optional[str] = None,
-        user: Optional[str] = None,
-        exclude_deletes: Optional[bool] = None,
-        inlcude_links: Optional[bool] = None,
-        include_push_data: Optional[bool] = None,
-        include_user_image_url: Optional[bool] = None,
-        include_work_items: Optional[bool] = None,
-        item_path: Optional[str] = None,
-        item_version: Optional[str] = None,
-        item_version_options: Optional[GitVersionOptions] = None,
-        item_version_type: Optional[GitVersionType] = None,
+        skip: int | None = None,
+        top: int | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        from_commit_id: str | None = None,
+        to_commit_id: str | None = None,
+        author: str | None = None,
+        user: str | None = None,
+        exclude_deletes: bool | None = None,
+        inlcude_links: bool | None = None,
+        include_push_data: bool | None = None,
+        include_user_image_url: bool | None = None,
+        include_work_items: bool | None = None,
+        item_path: str | None = None,
+        item_version: str | None = None,
+        item_version_options: GitVersionOptions | None = None,
+        item_version_type: GitVersionType | None = None,
     ) -> ADOResponse:
         """Retrieve git commits for a project
 
         All non-specified options use the ADO default.
 
-        :param str project_id: The ID of the project
-        :param str repository_id: The ID for the repository
-        :param Optional[int] skip: Number of entries to skip
-        :param Optional[int] top: Maximum number of entries to retrieve
-        :param Optional[str] from_date: If provided, only include history entries created after this date
-        :param Optional[str] to_date: If provided, only include history entries created before this date
-        :param Optional[str] from_commit_id: If provided, a lower bound for filtering commits alphabetically
-        :param Optional[str] to_commit_id: If provided, an upper bound for filtering commits alphabetically
-        :param Optional[str] author: Alias or display name of the author
-        :param Optional[str] user: Alias or display name of the committer
-        :param Optional[bool] exclude_deletes: If itemPath is specified, determines whether to exclude delete entries of the specified path.
-        :param Optional[bool] inlcude_links: Whether to include the _links field on the shallow references
-        :param Optional[bool] include_push_data: Whether to include the push information
-        :param Optional[bool] include_user_image_url: Whether to include the image Url for committers and authors
-        :param Optional[bool] include_work_items: Whether to include linked work items
-        :param Optional[str] item_path: Path of item to search under
-        :param Optional[str] item_version: Version string identifier (name of tag/branch, SHA1 of commit)
-        :param Optional[GitVersionOptions] item_version_options: Version options - Specify additional modifiers to version (e.g Previous)
-        :param Optional[GitVersionType] item_version_type: Version type (branch, tag, or commit). Determines how Id is interpreted
+        :param project_id: The ID of the project
+        :param repository_id: The ID for the repository
+        :param skip: Number of entries to skip
+        :param top: Maximum number of entries to retrieve
+        :param from_date: If provided, only include history entries created after this date
+        :param to_date: If provided, only include history entries created before this date
+        :param from_commit_id: If provided, a lower bound for filtering commits alphabetically
+        :param to_commit_id: If provided, an upper bound for filtering commits alphabetically
+        :param author: Alias or display name of the author
+        :param user: Alias or display name of the committer
+        :param exclude_deletes: If itemPath is specified, determines whether to exclude delete entries of the specified path.
+        :param inlcude_links: Whether to include the _links field on the shallow references
+        :param include_push_data: Whether to include the push information
+        :param include_user_image_url: Whether to include the image Url for committers and authors
+        :param include_work_items: Whether to include linked work items
+        :param item_path: Path of item to search under
+        :param item_version: Version string identifier (name of tag/branch, SHA1 of commit)
+        :param item_version_options: Version options - Specify additional modifiers to version (e.g Previous)
+        :param item_version_type: Version type (branch, tag, or commit). Determines how Id is interpreted
 
         :returns: The ADO response with the data in it
         """
@@ -640,7 +637,7 @@ class ADOGitClient(ADOBaseClient):
 
         request_url = f"{self.http_client.api_endpoint(project_id=project_id)}/git/repositories/{repository_id}/commits?"
 
-        parameters: Dict[str, Any] = {"api-version": "7.2-preview.2"}
+        parameters: dict[str, Any] = {"api-version": "7.2-preview.2"}
 
         if skip is not None:
             parameters["$skip"] = skip
@@ -698,7 +695,7 @@ class ADOGitClient(ADOBaseClient):
         response = self.http_client.get(request_url)
         return self.http_client.decode_response(response)
 
-    # pylint: enable=too-many-locals, line-too-long
+    # pylint: disable=too-many-locals,line-too-long,too-complex,too-many-branches
 
     class BlobFormat(enum.Enum):
         """The type of format to get a blob in."""
@@ -714,22 +711,22 @@ class ADOGitClient(ADOBaseClient):
         blob_id: str,
         project_id: str,
         repository_id: str,
-        blob_format: Optional[BlobFormat] = None,
-        download: Optional[bool] = None,
-        file_name: Optional[str] = None,
-        resolve_lfs: Optional[bool] = None,
+        blob_format: BlobFormat | None = None,
+        download: bool | None = None,
+        file_name: str | None = None,
+        resolve_lfs: bool | None = None,
     ) -> Any:
         """Get a git item.
 
         All non-specified options use the ADO default.
 
-        :param str blob_id: The SHA1 of the blob
-        :param str project_id: The ID for the project
-        :param str repository_id: The ID for the repository
-        :param Optional[BlobFormat] blob_format: The format to get the blob in
-        :param Optional[bool] download: Set to True to download rather than get a response
-        :param Optional[str] file_name: The file name to use for the download if download is set to True
-        :param Optional[bool] resolve_lfs: Set to true to resolve LFS pointer files to resolve actual content
+        :param blob_id: The SHA1 of the blob
+        :param project_id: The ID for the project
+        :param repository_id: The ID for the repository
+        :param blob_format: The format to get the blob in
+        :param download: Set to True to download rather than get a response
+        :param file_name: The file name to use for the download if download is set to True
+        :param resolve_lfs: Set to true to resolve LFS pointer files to resolve actual content
 
         :returns: The data returned and the return type depends on what you set blob_format to
         """
@@ -741,7 +738,7 @@ class ADOGitClient(ADOBaseClient):
         )
         request_url += f"/git/repositories/{repository_id}/blobs/{blob_id}?"
 
-        parameters: Dict[str, Any] = {
+        parameters: dict[str, Any] = {
             "api-version": "5.1",
         }
 
@@ -774,7 +771,7 @@ class ADOGitClient(ADOBaseClient):
     def get_blobs(
         self,
         *,
-        blob_ids: List[str],
+        blob_ids: list[str],
         output_path: str,
         project_id: str,
         repository_id: str,
@@ -783,10 +780,10 @@ class ADOGitClient(ADOBaseClient):
 
         All non-specified options use the ADO default.
 
-        :param List[str] blob_ids: The SHA1s of the blobs
-        :param str output_path: The location to write out the zip to
-        :param str project_id: The ID for the project
-        :param str repository_id: The ID for the repository
+        :param blob_ids: The SHA1s of the blobs
+        :param output_path: The location to write out the zip to
+        :param project_id: The ID for the project
+        :param repository_id: The ID for the repository
 
         :raises FileExistsError: If the output path already exists
         """

--- a/simple_ado/governance.py
+++ b/simple_ado/governance.py
@@ -7,7 +7,7 @@
 
 import enum
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 import urllib.parse
 
 
@@ -50,10 +50,10 @@ class ADOGovernanceClient(ADOBaseClient):
     def __init__(self, http_client: ADOHTTPClient, log: logging.Logger) -> None:
         super().__init__(http_client, log.getChild("governance"))
 
-    def get_governed_repositories(self, *, project_id: str) -> Dict[str, Any]:
+    def get_governed_repositories(self, *, project_id: str) -> dict[str, Any]:
         """Get all governed repositories for the project
 
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
 
         :returns: The governed repositories
         """
@@ -68,12 +68,12 @@ class ADOGovernanceClient(ADOBaseClient):
         return self.http_client.extract_value(response_data)
 
     def get_governed_repository(
-        self, *, governed_repository_id: Union[str, int], project_id: str
-    ) -> Dict[str, Any]:
+        self, *, governed_repository_id: str | int, project_id: str
+    ) -> dict[str, Any]:
         """Get a particular governed repository.
 
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :returns: The governed repository details
         """
@@ -87,12 +87,12 @@ class ADOGovernanceClient(ADOBaseClient):
         return self.http_client.decode_response(response)
 
     def delete_governed_repository(
-        self, *, governed_repository_id: Union[str, int], project_id: str
+        self, *, governed_repository_id: str | int, project_id: str
     ) -> None:
         """Delete a governed repository.
 
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
         """
 
         request_url = self.http_client.api_endpoint(
@@ -104,13 +104,17 @@ class ADOGovernanceClient(ADOBaseClient):
         self.http_client.validate_response(response)
 
     def remove_policy(
-        self, *, policy_id: str, governed_repository_id: Union[str, int], project_id: str
+        self,
+        *,
+        policy_id: str,
+        governed_repository_id: str | int,
+        project_id: str,
     ) -> None:
         """Remove a policy from a repository.
 
-        :param str policy_id: The ID of the policy to remove
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param policy_id: The ID of the policy to remove
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :raises ADOHTTPException: If removing the policy failed
         """
@@ -126,21 +130,22 @@ class ADOGovernanceClient(ADOBaseClient):
 
         if not response.ok:
             raise ADOHTTPException(
-                f"Failed to remove policy {policy_id} from {governed_repository_id}", response
+                f"Failed to remove policy {policy_id} from {governed_repository_id}",
+                response,
             )
 
     def _set_alert_settings(
         self,
         *,
-        alert_settings: Dict[str, Any],
-        governed_repository_id: Union[str, int],
+        alert_settings: dict[str, Any],
+        governed_repository_id: str | int,
         project_id: str,
     ) -> None:
         """Set alert settings for governance for a repository.
 
-        :param Dict[str,Any] alert_settings: The settings for the alert on the repo
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param alert_settings: The settings for the alert on the repo
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :raises ADOHTTPException: If setting the alert settings failed
         """
@@ -156,16 +161,17 @@ class ADOGovernanceClient(ADOBaseClient):
 
         if not response.ok:
             raise ADOHTTPException(
-                f"Failed to set alert settings on repo {governed_repository_id}", response
+                f"Failed to set alert settings on repo {governed_repository_id}",
+                response,
             )
 
     def get_alert_settings(
-        self, *, governed_repository_id: Union[str, int], project_id: str
-    ) -> Dict[str, Any]:
+        self, *, governed_repository_id: str | int, project_id: str
+    ) -> dict[str, Any]:
         """Get alert settings for governance for a repository.
 
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :returns: The settings for the alerts on the repo
         """
@@ -181,12 +187,12 @@ class ADOGovernanceClient(ADOBaseClient):
         return self.http_client.decode_response(response)
 
     def get_show_banner_in_repo_view(
-        self, *, governed_repository_id: Union[str, int], project_id: str
+        self, *, governed_repository_id: str | int, project_id: str
     ) -> bool:
         """Get whether to show the banner in the repo view or not.
 
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :returns: True if the banner is shown in the repo view, False otherwise
         """
@@ -198,13 +204,17 @@ class ADOGovernanceClient(ADOBaseClient):
         return current_settings["showRepositoryWarningBanner"]
 
     def set_show_banner_in_repo_view(
-        self, *, show_banner: bool, governed_repository_id: Union[str, int], project_id: str
+        self,
+        *,
+        show_banner: bool,
+        governed_repository_id: str | int,
+        project_id: str,
     ) -> None:
         """Set whether to show the banner in the repo view or not.
 
-        :param bool show_banner: Set to True to show the banner in the repo view, False to hide it
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param show_banner: Set to True to show the banner in the repo view, False to hide it
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
         """
 
         current_settings = self.get_alert_settings(
@@ -220,12 +230,12 @@ class ADOGovernanceClient(ADOBaseClient):
         )
 
     def get_minimum_alert_severity(
-        self, *, governed_repository_id: Union[str, int], project_id: str
+        self, *, governed_repository_id: str | int, project_id: str
     ) -> AlertSeverity:
         """Get the minimum severity to alert for.
 
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :returns: The minimum alert severity
         """
@@ -240,14 +250,14 @@ class ADOGovernanceClient(ADOBaseClient):
         self,
         *,
         alert_severity: AlertSeverity,
-        governed_repository_id: Union[str, int],
+        governed_repository_id: str | int,
         project_id: str,
     ) -> None:
         """Set the minimum severity to alert for.
 
-        :param AlertSeverity alert_severity: The minimum alert serverity to notify about
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param alert_severity: The minimum alert serverity to notify about
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
         """
 
         current_settings = self.get_alert_settings(
@@ -269,19 +279,19 @@ class ADOGovernanceClient(ADOBaseClient):
         create_for_legal_alerts: bool,
         area_path: str,
         work_item_type: str,
-        extra_fields: Optional[List[Tuple[str, str]]] = None,
-        governed_repository_id: Union[str, int],
+        extra_fields: list[tuple[str, str]] | None = None,
+        governed_repository_id: str | int,
         project_id: str,
     ) -> None:
         """Set whether to show the banner in the repo view or not.
 
-        :param bool create_for_security_alerts: Set to True to create work items for security alerts, False otherwise
-        :param bool create_for_legal_alerts: Set to True to create work items for legal alerts, False otherwise
-        :param str area_path: The area path to open the tickets under
-        :param str work_item_type: The type of work item to create (this must match one in your project)
+        :param create_for_security_alerts: Set to True to create work items for security alerts, False otherwise
+        :param create_for_legal_alerts: Set to True to create work items for legal alerts, False otherwise
+        :param area_path: The area path to open the tickets under
+        :param work_item_type: The type of work item to create (this must match one in your project)
         :param extra_fields: An optional list of tuples of field IDs and values to set on the created work item
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
         """
 
         current_settings = self.get_alert_settings(
@@ -314,9 +324,9 @@ class ADOGovernanceClient(ADOBaseClient):
         self,
         *,
         tracked_only: bool = True,
-        governed_repository_id: Union[str, int],
+        governed_repository_id: str | int,
         project_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get the branches for the goverened repository.
 
         Note: Due to lack of documentation, the pagination for this API is
@@ -324,9 +334,9 @@ class ADOGovernanceClient(ADOBaseClient):
         If there are any more than this, the call will return the top 99,999 and
         exit.
 
-        :param bool tracked_only: Set to True if only tracked branches should be returned (default), False otherwise
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param tracked_only: Set to True if only tracked branches should be returned (default), False otherwise
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :returns: The settings for the alerts on the repo
         """
@@ -352,17 +362,17 @@ class ADOGovernanceClient(ADOBaseClient):
         branch_name: str,
         include_history: bool = False,
         include_development_dependencies: bool = True,
-        governed_repository_id: Union[str, int],
+        governed_repository_id: str | int,
         project_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get the alerts on a given branch.
 
-        :param str branch_name: The branch to get the alerts for
-        :param bool include_history: It isn't clear what this parameter does. Defaults to False
-        :param bool include_development_dependencies: Set to True to include alerts on development
+        :param branch_name: The branch to get the alerts for
+        :param include_history: It isn't clear what this parameter does. Defaults to False
+        :param include_development_dependencies: Set to True to include alerts on development
                                                       dependencies, False otherwise (defaults to True)
-        :param Union[str,int] governed_repository_id: The repository governance ID
-        :param str project_id: The ID of the project
+        :param governed_repository_id: The repository governance ID
+        :param project_id: The ID of the project
 
         :returns: The settings for the alerts on the repo
         """

--- a/simple_ado/graph.py
+++ b/simple_ado/graph.py
@@ -4,7 +4,7 @@
 """ADO graph API wrapper."""
 
 import logging
-from typing import Any, Iterator, List, Optional
+from typing import Any, Iterator
 
 
 from simple_ado.base_client import ADOBaseClient
@@ -47,7 +47,7 @@ class ADOGraphClient(ADOBaseClient):
         response = self.http_client.get(request_url)
         return self.http_client.decode_response(response)
 
-    def lookup_subjects(self, subject_descriptors: List[str]) -> List[Any]:
+    def lookup_subjects(self, subject_descriptors: list[str]) -> list[Any]:
         """Lookup the various subject descriptors.
 
         :param subject_descriptors: Descriptors of the subjects to resolve
@@ -64,7 +64,7 @@ class ADOGraphClient(ADOBaseClient):
         response_data = self.http_client.decode_response(response)
         return self.http_client.extract_value(response_data)
 
-    def list_groups(self, *, scope_descriptor: Optional[str] = None) -> List[Any]:
+    def list_groups(self, *, scope_descriptor: str | None = None) -> list[Any]:
         """Get the groups in the organization.
 
         :param scope_descriptor: Specify a non-default scope (collection, project) to search for groups.
@@ -77,7 +77,7 @@ class ADOGraphClient(ADOBaseClient):
         if scope_descriptor:
             request_url += f"&scopeDescriptor={scope_descriptor}"
 
-        groups: List[Any] = []
+        groups: list[Any] = []
         continuation_token = None
 
         while True:

--- a/simple_ado/identities.py
+++ b/simple_ado/identities.py
@@ -6,7 +6,7 @@
 """ADO identities API wrapper."""
 
 import logging
-from typing import Any, cast, Dict, List
+from typing import Any, cast
 
 from simple_ado.base_client import ADOBaseClient
 from simple_ado.exceptions import ADOException
@@ -24,10 +24,10 @@ class ADOIdentitiesClient(ADOBaseClient):
     def __init__(self, http_client: ADOHTTPClient, log: logging.Logger) -> None:
         super().__init__(http_client, log.getChild("user"))
 
-    def search(self, identity: str) -> List[Dict[str, Any]]:
+    def search(self, identity: str) -> list[dict[str, Any]]:
         """Fetch the unique Team Foundation GUID for a given identity.
 
-        :param str identity: The identity to fetch for (should be email for users and display name for groups)
+        :param identity: The identity to fetch for (should be email for users and display name for groups)
 
         :returns: The found identities
 
@@ -45,7 +45,7 @@ class ADOIdentitiesClient(ADOBaseClient):
     def get_team_foundation_id(self, identity: str) -> TeamFoundationId:
         """Fetch the unique Team Foundation GUID for a given identity.
 
-        :param str identity: The identity to fetch for (should be email for users and display name for groups)
+        :param identity: The identity to fetch for (should be email for users and display name for groups)
 
         :returns: The team foundation ID
 

--- a/simple_ado/models/operations.py
+++ b/simple_ado/models/operations.py
@@ -1,7 +1,7 @@
 """ADO Operations."""
 
 import enum
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class OperationType(enum.Enum):
@@ -20,15 +20,15 @@ class PatchOperation:
 
     operation: OperationType
     path: str
-    value: Optional[Any]
-    from_path: Optional[str]
+    value: Any | None
+    from_path: str | None
 
     def __init__(
         self,
         operation: OperationType,
         path: str,
-        value: Optional[Any],
-        from_path: Optional[str] = None,
+        value: Any | None,
+        from_path: str | None = None,
     ):
         """Create a new PatchOperation.
 
@@ -42,7 +42,7 @@ class PatchOperation:
         self.value = value
         self.from_path = from_path
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """Serialize for sending to ADO.
 
         :returns: A dictionary.

--- a/simple_ado/models/property.py
+++ b/simple_ado/models/property.py
@@ -1,7 +1,7 @@
 """Property handling."""
 
 import datetime
-from typing import Any, Dict
+from typing import Any
 
 import deserialize
 
@@ -18,7 +18,7 @@ class PropertyValue:
         self.property_type = property_type
         self.value = None
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """Serialize to an ADO compatible format.
 
         :returns: A dictionary to be sent to ADO
@@ -47,7 +47,7 @@ class StringPropertyValue(PropertyValue):
         super().__init__("System.String")
         self.value = value
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """Serialize to an ADO compatible format.
 
         :returns: A dictionary to be sent to ADO
@@ -70,7 +70,7 @@ class IntPropertyValue(PropertyValue):
         super().__init__("System.Int32")
         self.value = value
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """Serialize to an ADO compatible format.
 
         :returns: A dictionary to be sent to ADO
@@ -93,7 +93,7 @@ class DateTimePropertyValue(PropertyValue):
         super().__init__("System.DateTime")
         self.value = value
 
-    def serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> dict[str, Any]:
         """Serialize to an ADO compatible format.
 
         :returns: A dictionary to be sent to ADO

--- a/simple_ado/pipelines.py
+++ b/simple_ado/pipelines.py
@@ -6,7 +6,7 @@
 """ADO pipeline API wrapper."""
 
 import logging
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Iterator
 import urllib.parse
 
 
@@ -27,10 +27,10 @@ class ADOPipelineClient(ADOBaseClient):
     def get_pipelines(
         self,
         *,
-        top: Optional[int] = None,
-        order_by: Optional[str] = None,
+        top: int | None = None,
+        order_by: str | None = None,
         project_id: str,
-    ) -> Iterator[Dict[str, Any]]:
+    ) -> Iterator[dict[str, Any]]:
         """Get all the pipelines in the project.
 
         Note: This hasn't been tested with continuation tokens.
@@ -42,7 +42,7 @@ class ADOPipelineClient(ADOBaseClient):
         :returns: The pipelines in the project
         """
 
-        parameters: Dict[str, Any] = {"api-version": "7.1-preview.1"}
+        parameters: dict[str, Any] = {"api-version": "7.1-preview.1"}
 
         if top:
             parameters["$top"] = top
@@ -67,7 +67,11 @@ class ADOPipelineClient(ADOBaseClient):
             url = request_url + f"&continuationToken={continuation_token}"
 
     def get_pipeline(
-        self, *, project_id: str, pipeline_id: int, pipeline_version: Optional[int] = None
+        self,
+        *,
+        project_id: str,
+        pipeline_id: int,
+        pipeline_version: int | None = None,
     ) -> ADOResponse:
         """Get the info for a pipeline.
 
@@ -90,8 +94,12 @@ class ADOPipelineClient(ADOBaseClient):
         return self.http_client.decode_response(response)
 
     def preview(
-        self, *, project_id: str, pipeline_id: int, pipeline_version: Optional[int] = None
-    ) -> Optional[str]:
+        self,
+        *,
+        project_id: str,
+        pipeline_id: int,
+        pipeline_version: int | None = None,
+    ) -> str | None:
         """Queue a dry run of the pipeline to return the final yaml.
 
         :param project_id: The ID of the project

--- a/simple_ado/pools.py
+++ b/simple_ado/pools.py
@@ -7,7 +7,7 @@
 
 import enum
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 import urllib.parse
 
 
@@ -36,13 +36,13 @@ class ADOPoolsClient(ADOBaseClient):
     def get_pools(
         self,
         *,
-        pool_name: Optional[str] = None,
-        action_filter: Optional[TaskAgentPoolActionFilter] = None,
+        pool_name: str | None = None,
+        action_filter: TaskAgentPoolActionFilter | None = None,
     ) -> ADOResponse:
         """Gets the agent details.
 
-        :param Optional[str] pool_name: The name of the pool to match on
-        :param Optional[TaskAgentPoolActionFilter] action_filter: Set to filter on the type of pools
+        :param pool_name: The name of the pool to match on
+        :param action_filter: Set to filter on the type of pools
 
         :returns: The ADO response with the data in it
         """
@@ -68,18 +68,18 @@ class ADOPoolsClient(ADOBaseClient):
         self,
         *,
         pool_id: int,
-        agent_name: Optional[str] = None,
+        agent_name: str | None = None,
         include_capabilities: bool = True,
         include_assigned_request: bool = True,
         include_last_completed_request: bool = True,
     ) -> ADOResponse:
         """Gets the agents details.
 
-        :param int pool_id: The ID of the pool the agents are in
-        :param Optional[str] agent_name: The name of the agent to match on
-        :param bool include_capabilities: Set to False to not include capabilities
-        :param bool include_assigned_request: Set to False to not include the current assigned request
-        :param bool include_last_completed_request: Set to False to not include the last completed request
+        :param pool_id: The ID of the pool the agents are in
+        :param agent_name: The name of the agent to match on
+        :param include_capabilities: Set to False to not include capabilities
+        :param include_assigned_request: Set to False to not include the current assigned request
+        :param include_last_completed_request: Set to False to not include the last completed request
 
         :returns: The ADO response with the data in it
         """
@@ -106,8 +106,8 @@ class ADOPoolsClient(ADOBaseClient):
     def get_agent(self, *, pool_id: int, agent_id: int) -> ADOResponse:
         """Gets the agent details.
 
-        :param int pool_id: The ID of the pool the agent is in
-        :param int agent_id: The ID of the agent to get
+        :param pool_id: The ID of the pool the agent is in
+        :param agent_id: The ID of the agent to get
 
         :returns: The ADO response with the data in it
         """
@@ -119,13 +119,13 @@ class ADOPoolsClient(ADOBaseClient):
         return self.http_client.decode_response(response)
 
     def update_agent(
-        self, *, pool_id: int, agent_id: int, agent_data: Dict[str, Any]
+        self, *, pool_id: int, agent_id: int, agent_data: dict[str, Any]
     ) -> ADOResponse:
         """Adds required reviewers when opening PRs against a given branch.
 
-        :param int pool_id: The ID of the pool the agent is in
-        :param int agent_id: The ID of the agent to disable
-        :param Dict[str,Any] agent_data: The data to set on the agent
+        :param pool_id: The ID of the pool the agent is in
+        :param agent_id: The ID of the agent to disable
+        :param agent_data: The data to set on the agent
 
         :returns: The ADO response with the data in it
         """
@@ -139,9 +139,9 @@ class ADOPoolsClient(ADOBaseClient):
     def set_agent_state(self, *, pool_id: int, agent_id: int, enabled: bool) -> ADOResponse:
         """Set the enabled/disabled state of an agent.
 
-        :param int pool_id: The ID of the pool the agent is in
-        :param int agent_id: The ID of the agent to disable
-        :param bool enabled: Set to True to enable an agent, False to disable it
+        :param pool_id: The ID of the pool the agent is in
+        :param agent_id: The ID of the agent to disable
+        :param enabled: Set to True to enable an agent, False to disable it
 
         :returns: The ADO response with the data in it
         """
@@ -151,13 +151,13 @@ class ADOPoolsClient(ADOBaseClient):
         return self.update_agent(pool_id=pool_id, agent_id=agent_id, agent_data=agent_details)
 
     def update_agent_capabilities(
-        self, *, pool_id: int, agent_id: int, capabilities: Dict[str, str]
+        self, *, pool_id: int, agent_id: int, capabilities: dict[str, str]
     ) -> ADOResponse:
         """Set the enabled/disabled state of an agent.
 
-        :param int pool_id: The ID of the pool the agent is in
-        :param int agent_id: The ID of the agent to disable
-        :param Dict[str,str] capabilities: The new capabilities to set
+        :param pool_id: The ID of the pool the agent is in
+        :param agent_id: The ID of the agent to disable
+        :param capabilities: The new capabilities to set
 
         :returns: The ADO response with the data in it
         """

--- a/simple_ado/pull_requests.py
+++ b/simple_ado/pull_requests.py
@@ -255,7 +255,6 @@ class ADOPullRequestClient(ADOBaseClient):
             request_url += f"/comments/{comment_id}?api-version=3.0-preview"
             requests.delete(
                 request_url,
-                auth=self.http_client.credentials,
                 headers=self.http_client.construct_headers(),
             )
 

--- a/simple_ado/pull_requests.py
+++ b/simple_ado/pull_requests.py
@@ -7,7 +7,7 @@
 
 import enum
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import deserialize
 import requests
@@ -23,7 +23,12 @@ from simple_ado.exceptions import ADOException
 from simple_ado.git import ADOGitStatusState
 from simple_ado.http_client import ADOHTTPClient, ADOResponse, ADOThread
 
-from simple_ado.models import PatchOperation, AddOperation, DeleteOperation, PropertyValue
+from simple_ado.models import (
+    PatchOperation,
+    AddOperation,
+    DeleteOperation,
+    PropertyValue,
+)
 
 
 class ADOPullRequestStatus(enum.Enum):
@@ -108,10 +113,10 @@ class ADOPullRequestClient(ADOBaseClient):
         response_data = self.http_client.decode_response(response)
         return self.http_client.extract_value(response_data)
 
-    def get_threads(self, *, include_deleted: bool = False) -> List[ADOThread]:
+    def get_threads(self, *, include_deleted: bool = False) -> list[ADOThread]:
         """Get the comments on the PR from ADO.
 
-        :param bool include_deleted: Set to True if deleted threads should be included.
+        :param include_deleted: Set to True if deleted threads should be included.
 
         :returns: A list of ADOThreads that were found
         """
@@ -124,7 +129,7 @@ class ADOPullRequestClient(ADOBaseClient):
         )
         response = self.http_client.get(request_url)
         response_data = self.http_client.decode_response(response)
-        comments: List[ADOThread] = self.http_client.extract_value(response_data)
+        comments: list[ADOThread] = self.http_client.extract_value(response_data)
 
         if include_deleted:
             return comments
@@ -135,16 +140,16 @@ class ADOPullRequestClient(ADOBaseClient):
         self,
         comment_text: str,
         *,
-        comment_location: Optional[ADOCommentLocation] = None,
-        status: Optional[ADOCommentStatus] = None,
-        comment_identifier: Optional[str] = None,
+        comment_location: ADOCommentLocation | None = None,
+        status: ADOCommentStatus | None = None,
+        comment_identifier: str | None = None,
     ) -> ADOResponse:
         """Create a thread using a single root comment.
 
-        :param str comment_text: The text to set in the comment.
-        :param Optional[ADOCommentLocation] comment_location: The location to place the comment.
-        :param Optional[ADOCommentStatus] status: The status of the comment
-        :param Optional[str] comment_identifier: A unique identifier for the comment that can be used for identification
+        :param comment_text: The text to set in the comment.
+        :param comment_location: The location to place the comment.
+        :param status: The status of the comment
+        :param comment_identifier: A unique identifier for the comment that can be used for identification
                                                  at a later date
 
         :returns: The ADO response with the data in it
@@ -162,14 +167,14 @@ class ADOPullRequestClient(ADOBaseClient):
         self,
         comment: ADOComment,
         *,
-        status: Optional[ADOCommentStatus] = None,
-        comment_identifier: Optional[str] = None,
+        status: ADOCommentStatus | None = None,
+        comment_identifier: str | None = None,
     ) -> ADOResponse:
         """Create a thread using a single root comment.
 
-        :param ADOComment comment: The comment to add.
-        :param Optional[ADOCommentStatus] status: The status of the comment
-        :param Optional[str] comment_identifier: A unique identifier for the comment that can be used for identification
+        :param comment: The comment to add.
+        :param status: The status of the comment
+        :param comment_identifier: A unique identifier for the comment that can be used for identification
                                                  at a later date
 
         :returns: The ADO response with the data in it
@@ -186,17 +191,17 @@ class ADOPullRequestClient(ADOBaseClient):
     def create_thread(
         self,
         *,
-        comments: List[Dict[str, Any]],
-        thread_location: Optional[ADOCommentLocation] = None,
-        status: Optional[ADOCommentStatus] = None,
-        comment_identifier: Optional[str] = None,
+        comments: list[dict[str, Any]],
+        thread_location: ADOCommentLocation | None = None,
+        status: ADOCommentStatus | None = None,
+        comment_identifier: str | None = None,
     ) -> ADOResponse:
         """Create a thread on a PR.
 
-        :param List[Dict[str,Any]] comments: The comments to add to the thread.
-        :param Optional[ADOCommentLocation] thread_location: The location the thread should be added
-        :param Optional[ADOCommentStatus] status: The status of the comment
-        :param Optional[str] comment_identifier: A unique identifier for the comment that can be used for identification
+        :param comments: The comments to add to the thread.
+        :param thread_location: The location the thread should be added
+        :param status: The status of the comment
+        :param comment_identifier: A unique identifier for the comment that can be used for identification
                                                  at a later date
 
         :returns: The ADO response with the data in it
@@ -222,7 +227,7 @@ class ADOPullRequestClient(ADOBaseClient):
         body = {
             "comments": comments,
             "properties": properties,
-            "status": status.value if status is not None else ADOCommentStatus.ACTIVE.value,
+            "status": (status.value if status is not None else ADOCommentStatus.ACTIVE.value),
         }
 
         if thread_location is not None:
@@ -257,13 +262,13 @@ class ADOPullRequestClient(ADOBaseClient):
     def create_thread_list(
         self,
         *,
-        threads: List[ADOComment],
-        comment_identifier: Optional[str] = None,
+        threads: list[ADOComment],
+        comment_identifier: str | None = None,
     ) -> None:
         """Create a list of threads
 
-        :param List[ADOComment] threads: The threads to create
-        :param Optional[str] comment_identifier: A unique identifier for the comments that can be used for
+        :param threads: The threads to create
+        :param comment_identifier: A unique identifier for the comments that can be used for
                                                  identification at a later date
 
         :raises ADOException: If a thread is not an ADO comment
@@ -304,17 +309,17 @@ class ADOPullRequestClient(ADOBaseClient):
         description: str,
         context: str,
         *,
-        iteration: Optional[int] = None,
-        target_url: Optional[str] = None,
+        iteration: int | None = None,
+        target_url: str | None = None,
     ) -> ADOResponse:
         """Set a status on a PR.
 
-        :param ADOGitStatusState state: The state to set the status to.
-        :param str identifier: A unique identifier for the status (so it can be changed later)
-        :param str description: The text to show in the status
-        :param str context: The context for the build status
-        :param Optional[int] iteration: The iteration of the PR to set the status on
-        :param Optional[str] target_url: An optional URL to set which is opened when the description is clicked.
+        :param state: The state to set the status to.
+        :param identifier: A unique identifier for the status (so it can be changed later)
+        :param description: The text to show in the status
+        :param context: The context for the build status
+        :param iteration: The iteration of the PR to set the status on
+        :param target_url: An optional URL to set which is opened when the description is clicked.
 
         :returns: The ADO response with the data in it
         """
@@ -329,7 +334,7 @@ class ADOPullRequestClient(ADOBaseClient):
             + f"/pullRequests/{self.pull_request_id}/statuses?api-version=4.0-preview"
         )
 
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "state": state.value,
             "description": description,
             "context": {"name": context, "genre": identifier},
@@ -386,10 +391,10 @@ class ADOPullRequestClient(ADOBaseClient):
 
         return False
 
-    def threads_with_identifier(self, identifier: str) -> List[ADOThread]:
+    def threads_with_identifier(self, identifier: str) -> list[ADOThread]:
         """Get the threads on a PR which begin with the prefix specified.
 
-        :param str identifier: The identifier to look for threads with
+        :param identifier: The identifier to look for threads with
 
         :returns: The list of threads matching the identifier
 
@@ -413,7 +418,7 @@ class ADOPullRequestClient(ADOBaseClient):
     def delete_threads_with_identifier(self, identifier: str) -> None:
         """Delete the threads on a PR which begin with the prefix specified.
 
-        :param str identifier: The identifier property value to look for threads matching
+        :param identifier: The identifier property value to look for threads matching
         """
 
         self.log.debug(
@@ -424,7 +429,7 @@ class ADOPullRequestClient(ADOBaseClient):
             self.log.debug(f"Deleting thread: {thread}")
             self.delete_thread(thread=thread)
 
-    def get_properties(self) -> Dict[str, PropertyValue]:
+    def get_properties(self) -> dict[str, PropertyValue]:
         """Get the properties on the PR from ADO.
 
         :returns: The properties that were found
@@ -440,11 +445,11 @@ class ADOPullRequestClient(ADOBaseClient):
         response_data = self.http_client.decode_response(response)
         raw_properties = self.http_client.extract_value(response_data)
 
-        properties = deserialize.deserialize(Dict[str, PropertyValue], raw_properties)
+        properties = deserialize.deserialize(dict[str, PropertyValue], raw_properties)
 
         return properties
 
-    def patch_properties(self, operations: List[PatchOperation]) -> Dict[str, PropertyValue]:
+    def patch_properties(self, operations: list[PatchOperation]) -> dict[str, PropertyValue]:
         """Patch the properties on the PR.
 
         Usually add_property(), delete_property() and update_property() are
@@ -467,11 +472,11 @@ class ADOPullRequestClient(ADOBaseClient):
         response_data = self.http_client.decode_response(response)
         raw_properties = self.http_client.extract_value(response_data)
 
-        properties = deserialize.deserialize(Dict[str, PropertyValue], raw_properties)
+        properties = deserialize.deserialize(dict[str, PropertyValue], raw_properties)
 
         return properties
 
-    def add_property(self, name: str, value: str) -> Dict[str, PropertyValue]:
+    def add_property(self, name: str, value: str) -> dict[str, PropertyValue]:
         """Add a property to the PR.
 
         :param name: The name of the property to add
@@ -483,7 +488,7 @@ class ADOPullRequestClient(ADOBaseClient):
         operation = AddOperation("/" + name, value)
         return self.patch_properties([operation])
 
-    def delete_property(self, name: str) -> Dict[str, PropertyValue]:
+    def delete_property(self, name: str) -> dict[str, PropertyValue]:
         """Delete a property from the PR.
 
         :param name: The name of the property to delete

--- a/simple_ado/security.py
+++ b/simple_ado/security.py
@@ -8,7 +8,7 @@
 import enum
 import json
 import logging
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar
 import urllib.parse
 
 
@@ -21,22 +21,22 @@ from simple_ado.types import TeamFoundationId
 class ADOBranchPermission(enum.IntEnum):
     """Possible types of git branch permissions."""
 
-    ADMINISTER: int = 2 ** 0
-    READ: int = 2 ** 1
-    CONTRIBUTE: int = 2 ** 2
-    FORCE_PUSH: int = 2 ** 3
-    CREATE_BRANCH: int = 2 ** 4
-    CREATE_TAG: int = 2 ** 5
-    MANAGE_NOTES: int = 2 ** 6
-    BYPASS_PUSH_POLICIES: int = 2 ** 7
-    CREATE_REPOSITORY: int = 2 ** 8
-    DELETE_REPOSITORY: int = 2 ** 9
-    RENAME_REPOSITORY: int = 2 ** 10
-    EDIT_POLICIES: int = 2 ** 11
-    REMOVE_OTHERS_LOCKS: int = 2 ** 12
-    MANAGE_PERMISSIONS: int = 2 ** 13
-    CONTRIBUTE_TO_PULL_REQUESTS: int = 2 ** 14
-    BYPASS_PULL_REQUEST_POLICIES: int = 2 ** 15
+    ADMINISTER: int = 2**0
+    READ: int = 2**1
+    CONTRIBUTE: int = 2**2
+    FORCE_PUSH: int = 2**3
+    CREATE_BRANCH: int = 2**4
+    CREATE_TAG: int = 2**5
+    MANAGE_NOTES: int = 2**6
+    BYPASS_PUSH_POLICIES: int = 2**7
+    CREATE_REPOSITORY: int = 2**8
+    DELETE_REPOSITORY: int = 2**9
+    RENAME_REPOSITORY: int = 2**10
+    EDIT_POLICIES: int = 2**11
+    REMOVE_OTHERS_LOCKS: int = 2**12
+    MANAGE_PERMISSIONS: int = 2**13
+    CONTRIBUTE_TO_PULL_REQUESTS: int = 2**14
+    BYPASS_PULL_REQUEST_POLICIES: int = 2**15
 
 
 class ADOBranchPermissionLevel(enum.IntEnum):
@@ -114,10 +114,10 @@ class ADOSecurityClient(ADOBaseClient):
         branch: str,
         is_blocking: bool = True,
         is_enabled: bool = True,
-        required_status_author_id: Optional[str] = None,
-        default_display_name: Optional[str] = None,
+        required_status_author_id: str | None = None,
+        default_display_name: str | None = None,
         invalidate_on_source_update: bool = True,
-        filename_filter: Optional[List[str]] = None,
+        filename_filter: list[str] | None = None,
         applicability: ADOPolicyApplicability = ADOPolicyApplicability.APPLY_BY_DEFAULT,
         status_name: str,
         status_genre: str,
@@ -126,20 +126,20 @@ class ADOSecurityClient(ADOBaseClient):
     ) -> ADOResponse:
         """Adds a new status check policy for a given branch.
 
-        :param str branch: The git branch to set the policy for
-        :param bool is_blocking: Whether the status blocks PR completion or not.
-        :param bool is_enabled: Whether the status is enabled or not.
-        :param Optional[str] required_status_author_id: The ID of a required author (None if anyone)
-        :param Optional[str] default_display_name: The default display name for the policy
-        :param bool invalidate_on_source_update: Set to True to invalid the status when an update to
+        :param branch: The git branch to set the policy for
+        :param is_blocking: Whether the status blocks PR completion or not.
+        :param is_enabled: Whether the status is enabled or not.
+        :param required_status_author_id: The ID of a required author (None if anyone)
+        :param default_display_name: The default display name for the policy
+        :param invalidate_on_source_update: Set to True to invalid the status when an update to
                                                  the PR happens, False otherwise
-        :param Optional[List[str]] filename_filter: A list of file name filters this policy should
+        :param filename_filter: A list of file name filters this policy should
                                                     only apply to
-        :param ADOPolicyApplicability applicability: Set to apply always or just if the status is posted
-        :param str status_name: The name of the status
-        :param str status_genre: The genre of the status
-        :param str project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param applicability: Set to apply always or just if the status is posted
+        :param status_name: The name of the status
+        :param status_genre: The genre of the status
+        :param project_id: The identifier for the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -187,18 +187,18 @@ class ADOSecurityClient(ADOBaseClient):
         *,
         branch: str,
         build_definition_id: int,
-        build_expiration: Optional[int] = None,
+        build_expiration: int | None = None,
         project_id: str,
         repository_id: str,
     ) -> ADOResponse:
         """Adds a new build policy for a given branch.
 
-        :param str branch: The git branch to set the build policy for
-        :param int build_definition_id: The build definition to use when creating the build policy
-        :param int build_expiration: How long in minutes before the build expires. Set to None for
+        :param branch: The git branch to set the build policy for
+        :param build_definition_id: The build definition to use when creating the build policy
+        :param build_expiration: How long in minutes before the build expires. Set to None for
                                      immediately on changes to source branch.
-        :param str project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param project_id: The identifier for the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -219,7 +219,7 @@ class ADOSecurityClient(ADOBaseClient):
                 "displayName": None,
                 "queueOnSourceUpdateOnly": build_expiration is not None,
                 "manualQueueOnly": False,
-                "validDuration": build_expiration if build_expiration is not None else 0,
+                "validDuration": (build_expiration if build_expiration is not None else 0),
                 "scope": [
                     {
                         "refName": f"refs/heads/{branch}",
@@ -237,17 +237,17 @@ class ADOSecurityClient(ADOBaseClient):
         self,
         *,
         branch: str,
-        identities: List[str],
+        identities: list[str],
         project_id: str,
         repository_id: str,
     ) -> ADOResponse:
         """Adds required reviewers when opening PRs against a given branch.
 
-        :param str branch: The git branch to set required reviewers for
-        :param List[str] identities: A list of identities to become required
+        :param branch: The git branch to set required reviewers for
+        :param identities: A list of identities to become required
                                      reviewers (should be team foundation IDs)
-        :param str project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param project_id: The identifier for the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -294,12 +294,12 @@ class ADOSecurityClient(ADOBaseClient):
     ) -> ADOResponse:
         """Set minimum number of reviewers for a branch.
 
-        :param str branch: The git branch to set minimum number of reviewers on
-        :param int minimum_approver_count: The minimum number of approvals required
-        :param bool creator_vote_counts: Allow users to approve their own changes
-        :param bool reset_on_source_push: Reset reviewer votes when there are new changes
-        :param str project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param branch: The git branch to set minimum number of reviewers on
+        :param minimum_approver_count: The minimum number of approvals required
+        :param creator_vote_counts: Allow users to approve their own changes
+        :param reset_on_source_push: Reset reviewer votes when there are new changes
+        :param project_id: The identifier for the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -342,10 +342,10 @@ class ADOSecurityClient(ADOBaseClient):
     ) -> ADOResponse:
         """Set the work item policy for a branch.
 
-        :param str branch: The git branch to set the work item policy on
-        :param bool required: Whether or not linked work items should be mandatory
-        :param str project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param branch: The git branch to set the work item policy on
+        :param required: Whether or not linked work items should be mandatory
+        :param project_id: The identifier for the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -380,17 +380,17 @@ class ADOSecurityClient(ADOBaseClient):
         *,
         branch: str,
         identity: TeamFoundationId,
-        permissions: Dict[ADOBranchPermission, ADOBranchPermissionLevel],
+        permissions: dict[ADOBranchPermission, ADOBranchPermissionLevel],
         project_id: str,
         repository_id: str,
     ) -> ADOResponse:
         """Set permissions for an identity on a branch.
 
-        :param str branch: The git branch to set permissions on
-        :param TeamFoundationId identity: The identity to set permissions for (should be team foundation ID)
-        :param Dict[ADOBranchPermission,ADOBranchPermissionLevel] permissions: A dictionary of permissions to set
-        :param str project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param branch: The git branch to set permissions on
+        :param identity: The identity to set permissions for (should be team foundation ID)
+        :param permissions: A dictionary of permissions to set
+        :param project_id: The identifier for the project
+        :param repository_id: The ID for the repository
 
         :returns: The ADO response with the data in it
         """
@@ -413,7 +413,9 @@ class ADOSecurityClient(ADOBaseClient):
                     "PermissionBit": permission,
                     "NamespaceId": ADOSecurityClient.GIT_PERMISSIONS_NAMESPACE,
                     "Token": self.generate_updates_token(
-                        branch_name=branch, project_id=project_id, repository_id=repository_id
+                        branch_name=branch,
+                        project_id=project_id,
+                        repository_id=repository_id,
                     ),
                 }
             )
@@ -444,13 +446,13 @@ class ADOSecurityClient(ADOBaseClient):
         team_foundation_id: TeamFoundationId,
         project_id: str,
         repository_id: str,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """Fetch the descriptor identity information for a given identity.
 
-        :param str branch: The git branch of interest
-        :param TeamFoundationId team_foundation_id: the unique Team Foundation GUID for the identity
+        :param branch: The git branch of interest
+        :param team_foundation_id: the unique Team Foundation GUID for the identity
         :param project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param repository_id: The ID for the repository
 
         :returns: The raw descriptor info
 
@@ -495,9 +497,9 @@ class ADOSecurityClient(ADOBaseClient):
     ) -> str:
         """Generate the token required for reading identity details and writing permissions.
 
-        :param str branch: The git branch of interest
-        :param str project_id: The ID for the project
-        :param str repository_id: The ID for the repository
+        :param branch: The git branch of interest
+        :param project_id: The ID for the project
+        :param repository_id: The ID for the repository
 
         :returns: The permission token
         """
@@ -509,8 +511,8 @@ class ADOSecurityClient(ADOBaseClient):
         self,
         *,
         project_id: str,
-        repository_id: Optional[str] = None,
-        branch_name: Optional[str] = None,
+        repository_id: str | None = None,
+        branch_name: str | None = None,
     ) -> str:
         """Generate the token required for updating permissions.
 
@@ -544,9 +546,7 @@ class ADOSecurityClient(ADOBaseClient):
 
         return token + f"refs/heads/{encoded_branch}/"
 
-    def query_namespaces(
-        self, *, namespace_id: str, local_only: Optional[bool] = None
-    ) -> ADOResponse:
+    def query_namespaces(self, *, namespace_id: str, local_only: bool | None = None) -> ADOResponse:
         """Query a namespace
 
         :param namespace_id: The identifier for the namespace
@@ -570,8 +570,8 @@ class ADOSecurityClient(ADOBaseClient):
         self,
         *,
         namespace_id: str,
-        descriptors: Optional[List[str]] = None,
-        token: Optional[str] = None,
+        descriptors: list[str] | None = None,
+        token: str | None = None,
     ) -> ADOResponse:
         """Query a namespace
 
@@ -586,9 +586,11 @@ class ADOSecurityClient(ADOBaseClient):
             descriptors = []
 
         descriptors = [
-            "Microsoft.TeamFoundation.Identity;" + descriptor
-            if not descriptor.startswith("Microsoft.TeamFoundation.Identity;")
-            else descriptor
+            (
+                "Microsoft.TeamFoundation.Identity;" + descriptor
+                if not descriptor.startswith("Microsoft.TeamFoundation.Identity;")
+                else descriptor
+            )
             for descriptor in descriptors
         ]
 
@@ -614,13 +616,13 @@ class ADOSecurityClient(ADOBaseClient):
         team_foundation_id: TeamFoundationId,
         project_id: str,
         repository_id: str,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """Get the permissions for a branch
 
-        :param str branch: The name of the branch to get the permissions for
-        :param TeamFoundationId team_foundation_id: the unique Team Foundation GUID for the identity
+        :param branch: The name of the branch to get the permissions for
+        :param team_foundation_id: the unique Team Foundation GUID for the identity
         :param project_id: The identifier for the project
-        :param str repository_id: The ID for the repository
+        :param repository_id: The ID for the repository
 
         :returns: The raw descriptor info
 

--- a/simple_ado/utilities.py
+++ b/simple_ado/utilities.py
@@ -1,7 +1,7 @@
 """Utilities for dealing with the ADO REST API."""
 
 import logging
-from typing import Callable, Optional
+from typing import Callable
 
 import requests
 
@@ -23,13 +23,13 @@ def download_from_response_stream(
     response: requests.Response,
     output_path: str,
     log: logging.Logger,
-    callback: Optional[Callable[[int, int], None]] = None
+    callback: Callable[[int, int], None] | None = None,
 ) -> None:
     """Downloads a file from an already open response stream.
 
-    :param requests.Response response: The response to download from
-    :param str output_path: The path to write the file out to
-    :param logging.Logger log: The log to use for progress updates
+    :param response: The response to download from
+    :param output_path: The path to write the file out to
+    :param log: The log to use for progress updates
     :param callback: If supplied, this will be called on every new chunk to update progress to the caller
 
     :raises ADOHTTPException: If we fail to fetch the file for any reason
@@ -42,7 +42,6 @@ def download_from_response_stream(
         raise ADOHTTPException("Failed to fetch file", response)
 
     with open(output_path, "wb") as output_file:
-
         content_length_string = response.headers.get("content-length", "0")
 
         total_size = int(content_length_string)

--- a/simple_ado/wiki.py
+++ b/simple_ado/wiki.py
@@ -27,7 +27,7 @@ class ADOWikiClient(ADOBaseClient):
 
         :param page_id: Wiki page ID
         :param wiki_id: Wiki ID or Wiki name
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
 
         :returns: The ADO response with the data in it
 
@@ -47,7 +47,12 @@ class ADOWikiClient(ADOBaseClient):
         return etag
 
     def update_page(
-        self, page_id: str, wiki_id: str, project_id: str, content: str, current_version_etag: str
+        self,
+        page_id: str,
+        wiki_id: str,
+        project_id: str,
+        content: str,
+        current_version_etag: str,
     ) -> ADOResponse:
         """Update a the contents of a wiki page.
 
@@ -55,9 +60,9 @@ class ADOWikiClient(ADOBaseClient):
 
         :param page_id: Wiki page ID
         :param wiki_id: Wiki ID or Wiki name
-        :param str project_id: The ID of the project
-        :param str content: Content of the wiki page.
-        :param str current_version_etag: The ETag of the current wiki page to verify the update.
+        :param project_id: The ID of the project
+        :param content: Content of the wiki page.
+        :param current_version_etag: The ETag of the current wiki page to verify the update.
 
         :returns: The ADO response with the data in it
         """

--- a/simple_ado/workitems.py
+++ b/simple_ado/workitems.py
@@ -8,7 +8,8 @@
 import enum
 import logging
 import os
-from typing import Any, cast, Dict, List, Optional
+import typing
+from typing import Any, cast
 
 from simple_ado.base_client import ADOBaseClient
 from simple_ado.exceptions import ADOException, ADOHTTPException
@@ -28,14 +29,14 @@ class BatchRequest:
 
     method: str
     uri: str
-    headers: Dict[str, str]
+    headers: dict[str, str]
 
-    def __init__(self, method: str, uri: str, headers: Dict[str, str]) -> None:
+    def __init__(self, method: str, uri: str, headers: dict[str, str]) -> None:
         self.method = method
         self.uri = uri
         self.headers = headers
 
-    def body(self) -> Dict[str, Any]:
+    def body(self) -> dict[str, Any]:
         """Generate the body of the request to be used in the API call.
 
         :returns: A dictionary with the raw API data for the request
@@ -50,7 +51,7 @@ class DeleteBatchRequest(BatchRequest):
     :param headers: The headers to be sent with the batch request
     """
 
-    def __init__(self, uri: str, headers: Optional[Dict[str, str]] = None) -> None:
+    def __init__(self, uri: str, headers: dict[str, str] | None = None) -> None:
         if headers is None:
             headers = {}
 
@@ -111,7 +112,7 @@ class ADOWorkItemsClient(ADOBaseClient):
         """Get the data about a work item.
 
         :param identifier: The identifier of the work item
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
 
         :returns: The ADO response with the data in it
         """
@@ -124,11 +125,11 @@ class ADOWorkItemsClient(ADOBaseClient):
         response = self.http_client.get(request_url)
         return self.http_client.decode_response(response)
 
-    def list(self, identifiers: List[int], project_id: str) -> ADOResponse:
+    def list(self, identifiers: list[int], project_id: str) -> ADOResponse:
         """Get a list of work items.
 
         :param identifiers: The list of requested work item ids
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
 
         :returns: The ADO response with the data in it
         """
@@ -168,10 +169,10 @@ class ADOWorkItemsClient(ADOBaseClient):
         :param identifier: The identifier of the work item
         :param field: The field to add
         :param value: The value to set the field to
-        :param str project_id: The ID of the project
-        :param bool bypass_rules: Set to True if we should bypass validation
+        :param project_id: The ID of the project
+        :param bypass_rules: Set to True if we should bypass validation
                                   rules, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -203,7 +204,7 @@ class ADOWorkItemsClient(ADOBaseClient):
         identifier: str,
         path_to_attachment: str,
         project_id: str,
-        filename: Optional[str] = None,
+        filename: str | None = None,
         bypass_rules: bool = False,
         supress_notifications: bool = False,
     ) -> ADOResponse:
@@ -211,11 +212,11 @@ class ADOWorkItemsClient(ADOBaseClient):
 
         :param identifier: The identifier of the work item
         :param path_to_attachment: The path to the attachment on disk
-        :param str project_id: The ID of the project
-        :param Optional[str] filename: The new file name of the attachment
-        :param bool bypass_rules: Set to True if we should bypass validation
+        :param project_id: The ID of the project
+        :param filename: The new file name of the attachment
+        :param bypass_rules: Set to True if we should bypass validation
                                   rules, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -279,14 +280,14 @@ class ADOWorkItemsClient(ADOBaseClient):
     ) -> ADOResponse:
         """Add a link between a parent work item and another resource.
 
-        :param str parent_identifier: The identifier of the parent work item
-        :param str child_url: The URL of the child item to link to
-        :param WorkItemRelationType relation_type: The relationship type between
+        :param parent_identifier: The identifier of the parent work item
+        :param child_url: The URL of the child item to link to
+        :param relation_type: The relationship type between
                                                    the parent and the child
-        :param str project_id: The ID of the project
-        :param bool bypass_rules: Set to True if we should bypass validation
+        :param project_id: The ID of the project
+        :param bypass_rules: Set to True if we should bypass validation
                                   rules, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -297,7 +298,11 @@ class ADOWorkItemsClient(ADOBaseClient):
 
         operation = AddOperation(
             "/relations/-",
-            {"rel": relation_type.value, "url": child_url, "attributes": {"comment": ""}},
+            {
+                "rel": relation_type.value,
+                "url": child_url,
+                "attributes": {"comment": ""},
+            },
         )
 
         request_url = f"{self.http_client.api_endpoint(project_id=project_id)}/wit/workitems/{parent_identifier}"
@@ -327,12 +332,12 @@ class ADOWorkItemsClient(ADOBaseClient):
 
         :param parent_identifier: The identifier of the parent work item
         :param child_identifier: The identifier of the child work item
-        :param WorkItemRelationType relationship: The relationship type between
+        :param relationship: The relationship type between
                                                   the two work items
-        :param str project_id: The ID of the project
-        :param bool bypass_rules: Set to True if we should bypass validation
+        :param project_id: The ID of the project
+        :param bypass_rules: Set to True if we should bypass validation
                                   rules, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -359,12 +364,12 @@ class ADOWorkItemsClient(ADOBaseClient):
     ) -> ADOResponse:
         """Add a hyperlink link to a work item.
 
-        :param str identifier: The identifier of the work item
-        :param str hyperlink: The hyperlink to add to the work item
-        :param str project_id: The ID of the project
-        :param bool bypass_rules: Set to True if we should bypass validation
+        :param identifier: The identifier of the work item
+        :param hyperlink: The hyperlink to add to the work item
+        :param project_id: The ID of the project
+        :param bypass_rules: Set to True if we should bypass validation
                                   rules, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -383,7 +388,7 @@ class ADOWorkItemsClient(ADOBaseClient):
         self,
         *,
         item_type: str,
-        operations: List[AddOperation],
+        operations: typing.List[AddOperation],
         project_id: str,
         bypass_rules: bool = False,
         supress_notifications: bool = False,
@@ -393,10 +398,10 @@ class ADOWorkItemsClient(ADOBaseClient):
         :param item_type: The type of work item to create
         :param operations: The list of add operations to use to create the
                            ticket
-        :param str project_id: The ID of the project
-        :param bool bypass_rules: Set to True if we should bypass validation
+        :param project_id: The ID of the project
+        :param bypass_rules: Set to True if we should bypass validation
                                   rules, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -414,7 +419,7 @@ class ADOWorkItemsClient(ADOBaseClient):
 
         response = self.http_client.post(
             request_url,
-            operations=cast(List[PatchOperation], operations),
+            operations=cast(list[PatchOperation], operations),
             additional_headers={"Content-Type": "application/json-patch+json"},
         )
 
@@ -424,7 +429,7 @@ class ADOWorkItemsClient(ADOBaseClient):
         self,
         *,
         identifier: str,
-        operations: List[PatchOperation],
+        operations: typing.List[PatchOperation],
         project_id: str,
         bypass_rules: bool = False,
         supress_notifications: bool = False,
@@ -433,10 +438,10 @@ class ADOWorkItemsClient(ADOBaseClient):
 
         :param identifier: The identifier of the work item
         :param operations: The list of operations to use to update the ticket
-        :param str project_id: The ID of the project
-        :param bool bypass_rules: Set to True if we should bypass validation
+        :param project_id: The ID of the project
+        :param bypass_rules: Set to True if we should bypass validation
                                   rules, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -464,7 +469,7 @@ class ADOWorkItemsClient(ADOBaseClient):
         """Execute a WIQL query.
 
         :param query_string: The WIQL query string to execute
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
 
         :returns: The ADO response with the data in it
         """
@@ -483,7 +488,7 @@ class ADOWorkItemsClient(ADOBaseClient):
         """Gets the results of the query given the query ID.
 
         :param query_id: The query id to execute
-        :param str project_id: The ID of the project
+        :param project_id: The ID of the project
 
         :returns: The ADO response with the data in it
         """
@@ -507,10 +512,10 @@ class ADOWorkItemsClient(ADOBaseClient):
         """Delete a work item.
 
         :param identifier: The identifier of the work item
-        :param str project_id: The ID of the project
-        :param bool permanent: Set to True if we should permanently delete the
+        :param project_id: The ID of the project
+        :param permanent: Set to True if we should permanently delete the
                                work item, False otherwise
-        :param bool supress_notifications: Set to True if notifications for this
+        :param supress_notifications: Set to True if notifications for this
                                            change should be supressed, False
                                            otherwise
 
@@ -529,7 +534,8 @@ class ADOWorkItemsClient(ADOBaseClient):
         request_url += "&api-version=4.1"
 
         response = self.http_client.delete(
-            request_url, additional_headers={"Content-Type": "application/json-patch+json"}
+            request_url,
+            additional_headers={"Content-Type": "application/json-patch+json"},
         )
 
         if response.status_code != 204:
@@ -537,7 +543,7 @@ class ADOWorkItemsClient(ADOBaseClient):
 
         return self.http_client.decode_response(response)
 
-    def batch(self, operations: List[BatchRequest]) -> ADOResponse:
+    def batch(self, operations: typing.List[BatchRequest]) -> ADOResponse:
         """Run a batch operation.
 
         :param operations: The list of batch operations to run

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,7 +4,7 @@
 """Base test cases."""
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import toml
 from dotenv import load_dotenv

--- a/tests/test_simple_ado.py
+++ b/tests/test_simple_ado.py
@@ -27,10 +27,9 @@ class LibraryTests(unittest.TestCase):
     def setUp(self) -> None:
         """Set up method."""
         self.test_config = TestDetails()
-        self.client = simple_ado.ADOClient(
-            tenant=self.test_config.tenant,
-            credentials=(self.test_config.username, self.test_config.token),
-        )
+        # Generate the token using `azureauth ado token --output token`
+        auth = simple_ado.auth.ado_token_auth.ADOTokenAuth(self.test_config.token)
+        self.client = simple_ado.ADOClient(tenant=self.test_config.tenant, auth=auth)
 
     def test_access(self):
         """Test access."""

--- a/tests/test_simple_ado.py
+++ b/tests/test_simple_ado.py
@@ -61,9 +61,10 @@ class LibraryTests(unittest.TestCase):
     def test_git_diff(self):
         """Test git diff."""
         all_prs = self.client.list_all_pull_requests(
-            project_id=self.test_config.project_id, repository_id=self.test_config.repository_id
+            project_id=self.test_config.project_id,
+            repository_id=self.test_config.repository_id,
         )
-        details = all_prs[0]
+        details = next(all_prs)
         diff = self.client.git.diff_between_commits(
             base_commit=details["lastMergeTargetCommit"]["commitId"],
             target_commit=details["lastMergeSourceCommit"]["commitId"],
@@ -75,9 +76,10 @@ class LibraryTests(unittest.TestCase):
     def test_properties(self):
         """Test get properties."""
         all_prs = self.client.list_all_pull_requests(
-            project_id=self.test_config.project_id, repository_id=self.test_config.repository_id
+            project_id=self.test_config.project_id,
+            repository_id=self.test_config.repository_id,
         )
-        latest_pr = all_prs[0]
+        latest_pr = next(all_prs)
         pr_id = latest_pr["pullRequestId"]
         pr_id = 441259
         base_properties = self.client.pull_request(
@@ -120,14 +122,16 @@ class LibraryTests(unittest.TestCase):
     def test_list_refs(self):
         """Test list refs."""
         refs = self.client.git.get_refs(
-            project_id=self.test_config.project_id, repository_id=self.test_config.repository_id
+            project_id=self.test_config.project_id,
+            repository_id=self.test_config.repository_id,
         )
         self.assertTrue(len(refs) > 0, "Failed to find any refs")
 
     def test_get_commit(self):
         """Test get commit."""
         refs = self.client.git.get_refs(
-            project_id=self.test_config.project_id, repository_id=self.test_config.repository_id
+            project_id=self.test_config.project_id,
+            repository_id=self.test_config.repository_id,
         )
         ref = refs[0]
         commit_id = ref["objectId"]
@@ -148,7 +152,8 @@ class LibraryTests(unittest.TestCase):
     def test_get_pull_requests(self):
         """Test get pull requests."""
         refs = self.client.list_all_pull_requests(
-            project_id=self.test_config.project_id, repository_id=self.test_config.repository_id
+            project_id=self.test_config.project_id,
+            repository_id=self.test_config.repository_id,
         )
         self.assertTrue(len(refs) > 0)
 
@@ -172,9 +177,10 @@ class LibraryTests(unittest.TestCase):
     def test_get_pr_statuses(self):
         """Test get properties."""
         all_prs = self.client.list_all_pull_requests(
-            project_id=self.test_config.project_id, repository_id=self.test_config.repository_id
+            project_id=self.test_config.project_id,
+            repository_id=self.test_config.repository_id,
         )
-        latest_pr = all_prs[0]
+        latest_pr = next(all_prs)
         pr_id = latest_pr["pullRequestId"]
         statuses = self.client.pull_request(
             pr_id,
@@ -305,7 +311,9 @@ class LibraryTests(unittest.TestCase):
 
         for endpoint in endpoints:
             for item in self.client.endpoints.get_usage_history(
-                project_id=self.test_config.project_id, endpoint_id=endpoint["id"], top=75
+                project_id=self.test_config.project_id,
+                endpoint_id=endpoint["id"],
+                top=75,
             ):
                 assert item is not None
 
@@ -347,12 +355,14 @@ class LibraryTests(unittest.TestCase):
         """Test list PRs diff."""
         count = 0
         one_month_ago = datetime.datetime.now() - datetime.timedelta(days=28)
-        for pr in self.client.list_all_pull_requests(
+        for pull_request in self.client.list_all_pull_requests(
             project_id=self.test_config.project_id,
             repository_id=self.test_config.repository_id,
             pr_status=simple_ado.pull_requests.ADOPullRequestStatus.COMPLETED,
         ):
-            closed_date = datetime.datetime.strptime(pr["closedDate"][:-2], "%Y-%m-%dT%H:%M:%S.%f")
+            closed_date = datetime.datetime.strptime(
+                pull_request["closedDate"][:-2], "%Y-%m-%dT%H:%M:%S.%f"
+            )
             if closed_date < one_month_ago:
                 break
             count += 1


### PR DESCRIPTION
Depends on #39 being merged first.

ADO changed it's file downloads from using the same domain to using a different one. When the redirect happened, the `requests` library detected the domain change and stripped out the auth headers. There's no way to turn that feature off, so we have had to handle the redirect chain manually instead. 